### PR TITLE
Add Job model, ActiveJob adapter, and Sidekiq integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ publisher process handles retries and ensure that each job is delivered to Sidek
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'sidekiq_publisher'
+gem "sidekiq_publisher"
 ```
 
 And then execute:
@@ -34,7 +34,38 @@ Run the generator to create migrations for the jobs table and notifications:
     
 ## Usage
 
-TODO: Write usage instructions here
+### ActiveJob Adapter
+
+This gem includes an adapter to use `SidekiqPublisher` with `ActiveJob`. This
+adapter must be explicitly required:
+
+```ruby
+require "active_job/queue_adapters/sidekiq_publisher_adapter"
+```
+
+The adapter can also be required via your Gemfile:
+
+```ruby
+gem "sidekiq_publisher", require: ["sidekiq_publisher", "active_job/queue_adapters/sidekiq_publisher_adapter"]
+```
+
+The adapter to use with `ActiveJob` must be specified in Rails configuration
+
+```ruby
+# application.rb
+config.active_job.queue_adapter = :sidekiq_publisher
+
+# or directly in configuration
+Rails.application.config.active_job.queue_adapter = :sidekiq_publisher
+```
+
+### SidekiqPublisher::Worker
+
+Sidekiq workers are usually defined by including `Sidekiq::Worker` in a class.
+
+To use the `SidekiqPublisher`, this can be replaced by including
+`SidekiqPublisher::Worker`. The usual `perform_async`, etc methods will be
+available on the class but jobs will be staged in the Postgres table.
 
 ## Development
 

--- a/lib/active_job/queue_adapters/sidekiq_publisher_adapter.rb
+++ b/lib/active_job/queue_adapters/sidekiq_publisher_adapter.rb
@@ -1,0 +1,38 @@
+require "active_job/queue_adapters/sidekiq_adapter"
+
+module ActiveJob
+  module QueueAdapters
+    # To use SidekiqPublisher set the queue_adapter config to +:sidekiq_publisher+.
+    #   Rails.application.config.active_job.queue_adapter = :sidekiq_publisher
+    class SidekiqPublisherAdapter
+      JOB_WRAPPER_CLASS = ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper.to_s.freeze
+
+      def enqueue(job)
+        internal_enqueue(job)
+      end
+
+      def enqueue_at(job, timestamp)
+        internal_enqueue(job, timestamp)
+      end
+
+      private
+
+      def internal_enqueue(job, timestamp = nil)
+        job.provider_job_id = SidekiqPublisher::Job.generate_sidekiq_jid
+        attributes = job_attributes(job)
+        attributes[:run_at] = timestamp if timestamp.present?
+        SidekiqPublisher::Job.create!(attributes).job_id
+      end
+
+      def job_attributes(job)
+        {
+          job_id: job.provider_job_id,
+          job_class: JOB_WRAPPER_CLASS,
+          wrapped: job.class.to_s,
+          queue: job.queue_name,
+          args: [job.serialize],
+        }
+      end
+    end
+  end
+end

--- a/lib/generators/sidekiq_publisher/templates/create_sidekiq_publisher_jobs.rb
+++ b/lib/generators/sidekiq_publisher/templates/create_sidekiq_publisher_jobs.rb
@@ -4,8 +4,10 @@ class CreateSidekiqPublisherJobs < ActiveRecord::Migration[5.1]
     create_table(:sidekiq_publisher_jobs, id: :bigserial) do |t|
       t.string :job_id, null: false
       t.string :job_class, null: false
-      t.string :queue, null: false
+      t.string :queue
+      t.string :wrapped
       t.json :args, null: false
+      t.float :run_at
       t.timestamp :published_at
       t.timestamp :created_at, null: false
     end

--- a/lib/sidekiq_publisher.rb
+++ b/lib/sidekiq_publisher.rb
@@ -1,5 +1,4 @@
 require "sidekiq_publisher/version"
 require "sidekiq_publisher/job"
-
-module SidekiqPublisher
-end
+require "sidekiq_publisher/worker"
+require "active_job/queue_adapters/sidekiq_publisher_adapter"

--- a/lib/sidekiq_publisher/job.rb
+++ b/lib/sidekiq_publisher/job.rb
@@ -1,7 +1,45 @@
+# frozen_string_literal: true
+
 require "active_record"
 
 module SidekiqPublisher
   class Job < ActiveRecord::Base
-    self.table_name = "sidekiq_publisher_jobs".freeze
+    self.table_name = "sidekiq_publisher_jobs"
+
+    before_create :ensure_job_id
+    before_save :ensure_string_job_class
+
+    validates :job_class, presence: true
+    validates :args, exclusion: { in: [nil] }
+
+    def self.generate_sidekiq_jid
+      SecureRandom.hex(12)
+    end
+
+    # TODO: this method was just for testing and may be removed
+    def publish
+      Sidekiq::Client.push(sidekiq_item)
+    end
+
+    def sidekiq_item
+      {
+        "jid" => job_id,
+        "class" => job_class.constantize,
+        "args" => args,
+        "at" => run_at,
+        "queue" => queue,
+        "wrapped" => wrapped,
+      }.tap(&:compact!)
+    end
+
+    private
+
+    def ensure_job_id
+      self.job_id ||= self.class.generate_sidekiq_jid
+    end
+
+    def ensure_string_job_class
+      self.job_class = job_class.to_s
+    end
   end
 end

--- a/lib/sidekiq_publisher/worker.rb
+++ b/lib/sidekiq_publisher/worker.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module SidekiqPublisher
+  module Worker
+    def self.included(base)
+      base.include(Sidekiq::Worker)
+      base.extend(ClassMethods)
+    end
+
+    module ClassMethods
+      def client_push(item)
+        SidekiqPublisher::Job.create!(
+          job_class: item["class"].to_s,
+          args: item["args"],
+          run_at: item["at"],
+          queue: item["queue"]
+        )
+      end
+    end
+  end
+end

--- a/sidekiq_publisher.gemspec
+++ b/sidekiq_publisher.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |spec|
   spec.executables   = []
   spec.require_paths = ["lib"]
 
+  spec.add_development_dependency "activejob"
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "database_cleaner"
   spec.add_development_dependency "ezcater_rubocop", "~> 0.52.6"
@@ -49,6 +50,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "rspec_junit_formatter", "0.2.2"
+  spec.add_development_dependency "shoulda-matchers"
   spec.add_development_dependency "simplecov"
 
   spec.add_runtime_dependency "activerecord-postgres_pub_sub"

--- a/spec/active_job/queue_adapters/sidekiq_publisher_adapter_spec.rb
+++ b/spec/active_job/queue_adapters/sidekiq_publisher_adapter_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe ActiveJob::QueueAdapters::SidekiqPublisherAdapter do
+  let(:job_class) do
+    Class.new(ActiveJob::Base) do
+      self.queue_adapter = :sidekiq_publisher
+
+      def perform(*args); end
+    end
+  end
+  let(:args) { [1, 2, 3] }
+  let(:active_job) { job_class.new(*args) }
+  let(:job) { SidekiqPublisher::Job.last }
+
+  before do
+    stub_const("TestJob", job_class)
+  end
+
+  describe "#enqueue" do
+    it "creates a SidekiqPublisher job" do
+      active_job.enqueue
+
+      expect(job.job_class).to eq(described_class::JOB_WRAPPER_CLASS)
+      expect(job.wrapped).to eq("TestJob")
+      expect(job.args.first).to include("job_class" => "TestJob", "arguments" => args, "provider_job_id" => job.job_id)
+    end
+  end
+
+  describe "#enqueue_at" do
+    let(:scheduled_at) { 1.hour.from_now }
+
+    it "creates a SidekiqPublisher job with a run_at value" do
+      active_job.enqueue(wait_until: scheduled_at)
+
+      expect(job.job_class).to eq(described_class::JOB_WRAPPER_CLASS)
+      expect(job.wrapped).to eq("TestJob")
+      expect(job.args.first).to include("job_class" => "TestJob", "arguments" => args, "provider_job_id" => job.job_id)
+      expect(job.run_at).to be_within(1).of(scheduled_at.to_f)
+    end
+  end
+
+  describe "ActiveJob::Base.perform_later" do
+    it "creates a SidekiqPublisher job" do
+      job_class.perform_later(*args)
+
+      expect(job.job_class).to eq(described_class::JOB_WRAPPER_CLASS)
+      expect(job.wrapped).to eq("TestJob")
+      expect(job.args.dig(0, "arguments")).to eq(args)
+    end
+  end
+end

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -6,8 +6,10 @@ ActiveRecord::Schema.define do
   create_table(:sidekiq_publisher_jobs, id: :bigserial) do |t|
     t.string :job_id, null: false
     t.string :job_class, null: false
-    t.string :queue, null: false
+    t.string :queue
+    t.string :wrapped
     t.json :args, null: false
+    t.float :run_at
     t.timestamp :published_at
     t.timestamp :created_at, null: false
   end

--- a/spec/sidekiq_publisher/job_spec.rb
+++ b/spec/sidekiq_publisher/job_spec.rb
@@ -1,0 +1,82 @@
+RSpec.describe SidekiqPublisher::Job, type: :model do
+  let(:job_class) { Class.new }
+  let(:job_id) { described_class.generate_sidekiq_jid }
+
+  before do
+    stub_const("TestJob", job_class)
+  end
+
+  describe "#valid?" do
+    it { is_expected.to validate_presence_of(:job_class) }
+    it { is_expected.to validate_exclusion_of(:args).in_array([nil]) }
+  end
+
+  describe ".create!" do
+    it "sets a job_id if unset" do
+      job = described_class.create!(job_class: "Foo", args: [])
+      expect(job.job_id).to match(/^[0-9a-f]{24}$/)
+    end
+
+    it "ensures that job_class is a string" do
+      job = described_class.create!(job_class: TestJob, args: [])
+      expect(job.job_class).to eq("TestJob")
+    end
+  end
+
+  describe "#sidekiq_item" do
+    let(:expected_item) do
+      {
+        "jid" => job_id,
+        "class" => TestJob,
+        "args" => [1, 2],
+      }
+    end
+    let(:job) do
+      described_class.new(job_id: job_id, job_class: "TestJob", args: [1, 2])
+    end
+
+    it "returns the item to publish to Sidekiq" do
+      expect(job.sidekiq_item).to eq(expected_item)
+    end
+
+    context "all attributes" do
+      let(:expected_item) do
+        {
+          "jid" => job_id,
+          "class" => TestJob,
+          "args" => [1, 2],
+          "queue" => "default",
+          "at" => job.run_at,
+          "wrapped" => "Other",
+        }
+      end
+      let(:job) do
+        described_class.new(job_id: job_id,
+                            job_class: "TestJob",
+                            args: [1, 2],
+                            queue: "default",
+                            run_at: Time.now,
+                            wrapped: "Other")
+      end
+
+      it "returns the item to publish to Sidekiq" do
+        expect(job.sidekiq_item).to eq(expected_item)
+      end
+    end
+  end
+
+  describe "#publish" do
+    let(:args) { Hash["x" => 1] }
+    let(:job) { described_class.new(job_id: job_id, job_class: "TestJob", args: args) }
+
+    before do
+      allow(Sidekiq::Client).to receive(:push)
+    end
+
+    it "calls Sidekiq::Client.push with the item" do
+      job.publish
+      expect(Sidekiq::Client).to have_received(:push).
+        with("jid" => job_id, "class" => TestJob, "args" => args)
+    end
+  end
+end

--- a/spec/sidekiq_publisher/worker_spec.rb
+++ b/spec/sidekiq_publisher/worker_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe SidekiqPublisher::Worker do
+  let(:worker_class) do
+    Class.new do
+      include SidekiqPublisher::Worker
+    end
+  end
+  let(:args) { [1, 2, 3] }
+  let(:job) { SidekiqPublisher::Job.last }
+
+  before do
+    stub_const("TestWorker", worker_class)
+  end
+
+  describe ".perform_async" do
+    it "creates a SidekiqPublisher job" do
+      TestWorker.perform_async(*args)
+
+      expect(job.job_class).to eq("TestWorker")
+      expect(job.args).to eq(args)
+    end
+  end
+
+  context ".perform_in" do
+    it "creates a SidekiqPublisher job" do
+      TestWorker.perform_in(1.hour, *args)
+
+      expect(job.job_class).to eq("TestWorker")
+      expect(job.args).to eq(args)
+      expect(job.run_at).to be_within(1).of(1.hour.from_now.to_f)
+    end
+  end
+
+  context ".perform_at" do
+    let(:run_at) { 2.hours.from_now }
+
+    it "creates a SidekiqPublisher job" do
+      TestWorker.perform_at(run_at, *args)
+
+      expect(job.job_class).to eq("TestWorker")
+      expect(job.args).to eq(args)
+      expect(job.run_at).to be_within(1).of(run_at.to_f)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,9 +2,12 @@ $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "simplecov"
 SimpleCov.start
 
+require "active_job"
 require "sidekiq_publisher"
+require "active_job/queue_adapters/sidekiq_publisher_adapter"
 
 require "database_cleaner"
+require "shoulda-matchers"
 
 logger = Logger.new("log/test.log", level: :debug)
 ActiveRecord::Base.logger = logger
@@ -55,5 +58,13 @@ RSpec.configure do |config|
 
   config.after do
     DatabaseCleaner.clean
+  end
+end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :active_model
+    with.library :active_record
   end
 end


### PR DESCRIPTION
## What did we change?

- Added `SidekiqPublisher::Job` model corresponding to Postgres table where jobs are staged prior to enqueue in Sidekiq.
- Added `:sidekiq_publisher` adapter for integration with `ActiveJob`.
- Added `SidekiqPublisher::Worker` as an alternative to `Sidekiq::Worker` that will stage a job vs enqueuing directly to Sidekiq/Redis.

## Why are we doing this?

Working through these different paths for jobs getting into the table helped me to work through the data that we need to store for these different enqueue paths.

I was able to test out both of these code paths using some simple dummy jobs in ez-rails. The automatic publishing via notifications is not happening yet, so I tested using the `SidekiqPublisher::Job#publish` method.

## How was it tested?
- [x] Specs
- [x] Locally
- [ ] Staging
