### PR TITLE
Enable frozen string literal comment and auto-correct

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,7 @@ inherit_gem:
 Lint/UnneededDisable:
   Exclude:
     - "lib/generators/sidekiq_publisher/templates/create_sidekiq_publisher_jobs.rb"
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # TODO: this should be changed back to rubygems once the activerecord-postgres_pub_sub is public
 source "https://ezcater.jfrog.io/ezcater/api/gems/ezcater-gem-source"
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 require "sidekiq_publisher"

--- a/lib/active_job/queue_adapters/sidekiq_publisher_adapter.rb
+++ b/lib/active_job/queue_adapters/sidekiq_publisher_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_job/queue_adapters/sidekiq_adapter"
 
 module ActiveJob

--- a/lib/generators/sidekiq_publisher/templates/create_sidekiq_publisher_jobs.rb
+++ b/lib/generators/sidekiq_publisher/templates/create_sidekiq_publisher_jobs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateSidekiqPublisherJobs < ActiveRecord::Migration[5.1]
   def change
     # rubocop:disable Rails/CreateTableWithTimestamps

--- a/lib/sidekiq_publisher.rb
+++ b/lib/sidekiq_publisher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "sidekiq_publisher/version"
 require "sidekiq_publisher/job"
 require "sidekiq_publisher/worker"

--- a/lib/sidekiq_publisher/version.rb
+++ b/lib/sidekiq_publisher/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SidekiqPublisher
-  VERSION = "0.1.0.rc0".freeze
+  VERSION = "0.1.0.rc0"
 end

--- a/sidekiq_publisher.gemspec
+++ b/sidekiq_publisher.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "sidekiq_publisher/version"

--- a/spec/active_job/queue_adapters/sidekiq_publisher_adapter_spec.rb
+++ b/spec/active_job/queue_adapters/sidekiq_publisher_adapter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe ActiveJob::QueueAdapters::SidekiqPublisherAdapter do
   let(:job_class) do
     Class.new(ActiveJob::Base) do

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 ActiveRecord::Schema.define do
-  TABLE_NAME = "sidekiq_publisher_jobs".freeze
-  NOTIFICATION_NAME = "sidekiq_publisher_job".freeze
-  TABLE_MODULE = "sidekiq_publisher".freeze
+  TABLE_NAME = "sidekiq_publisher_jobs"
+  NOTIFICATION_NAME = "sidekiq_publisher_job"
+  TABLE_MODULE = "sidekiq_publisher"
 
   create_table(:sidekiq_publisher_jobs, id: :bigserial) do |t|
     t.string :job_id, null: false

--- a/spec/sidekiq_publisher/job_spec.rb
+++ b/spec/sidekiq_publisher/job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe SidekiqPublisher::Job, type: :model do
   let(:job_class) { Class.new }
   let(:job_id) { described_class.generate_sidekiq_jid }

--- a/spec/sidekiq_publisher/worker_spec.rb
+++ b/spec/sidekiq_publisher/worker_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe SidekiqPublisher::Worker do
   let(:worker_class) do
     Class.new do

--- a/spec/sidekiq_publisher_spec.rb
+++ b/spec/sidekiq_publisher_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe SidekiqPublisher do
   it "has a version number" do
     expect(SidekiqPublisher::VERSION).not_to be nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "simplecov"
 SimpleCov.start
@@ -12,7 +14,7 @@ require "shoulda-matchers"
 logger = Logger.new("log/test.log", level: :debug)
 ActiveRecord::Base.logger = logger
 
-DATABASE_NAME = "sidekiq_publisher_test".freeze
+DATABASE_NAME = "sidekiq_publisher_test"
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
## What did we change?

Enabled the `Style/FrozenStringLiteralComment` cop with the `always` style. Auto-corrected offenses, which removes `.freeze` from existing string literals.

## Why are we doing this?

To always add the comment, and not worry about freezing individual string literals.

This will be revisited if the Style Council decides on a different approach.

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
