### PR TITLE
Add client for heterogeneous bulk publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
         environment:
           - POSTGRES_USER: postgres
           - POSTGRES_DB: sidekiq_publisher_test
+      - image: redis:2.8
     steps:
       - checkout
 

--- a/lib/sidekiq_publisher.rb
+++ b/lib/sidekiq_publisher.rb
@@ -4,7 +4,7 @@ require "private_attr"
 require "sidekiq_publisher/version"
 require "sidekiq_publisher/job"
 require "sidekiq_publisher/worker"
-# require "sidekiq_publisher/publisher"
+require "sidekiq_publisher/client"
 
 module SidekiqPublisher
   DEFAULT_BATCH_SIZE = 100

--- a/lib/sidekiq_publisher/client.rb
+++ b/lib/sidekiq_publisher/client.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "sidekiq"
+
+module SidekiqPublisher
+  class Client < Sidekiq::Client
+    def bulk_push(items)
+      payloads = items.map do |item|
+        normed = normalize_item(item)
+        process_single(item["class"], normed)
+      end.compact
+
+      pushed = 0
+      with_connection do |conn|
+        conn.multi do
+          payloads.each do |payload|
+            atomic_push(conn, [payload])
+            pushed += 1
+          end
+        end
+      end
+
+      pushed
+    end
+
+    private
+
+    def with_connection(&blk)
+      @redis_pool.with(&blk)
+    end
+  end
+end

--- a/sidekiq_publisher.gemspec
+++ b/sidekiq_publisher.gemspec
@@ -51,6 +51,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "factory_bot"
   spec.add_development_dependency "overcommit"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "redis-namespace"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "rspec_junit_formatter", "0.2.2"
   spec.add_development_dependency "shoulda-matchers"
@@ -58,5 +59,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "activerecord-postgres_pub_sub"
   spec.add_runtime_dependency "private_attr"
-  spec.add_runtime_dependency "sidekiq"
+  spec.add_runtime_dependency "sidekiq", "~> 5.0.4"
 end

--- a/spec/sidekiq_publisher/client_spec.rb
+++ b/spec/sidekiq_publisher/client_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+RSpec.describe SidekiqPublisher::Client do
+  let(:client) { described_class.new }
+  let(:job_class) do
+    Class.new do
+      include SidekiqPublisher::Worker
+    end
+  end
+  let(:redis) { Sidekiq.redis { |conn| conn } }
+
+  before do
+    stub_const("TestJobClass", job_class)
+
+    Sidekiq.redis do |conn|
+      conn.scan_each do |key|
+        conn.del(key)
+      end
+    end
+  end
+
+  describe "#bulk_push" do
+    context "a single item" do
+      let(:args) { [1, 2, 3] }
+      let(:push!) { client.bulk_push([{ "class" => TestJobClass, "args" => args }]) }
+
+      it "enqueues a Sidekiq job" do
+        push!
+
+        expect(redis.llen("queue:default")).to eq(1)
+        expect(JSON.parse(redis.lindex("queue:default", 0))).to include("class" => "TestJobClass", "args" => args)
+      end
+
+      it "returns the count of jobs enqueued" do
+        expect(push!).to eq(1)
+      end
+    end
+
+    context "multiple items" do
+      let(:args_array) { [[1, 2, 3], [4, 5, 6]] }
+      let(:push!) do
+        client.bulk_push(args_array.map { |args| Hash["class" => TestJobClass, "args" => args] })
+      end
+
+      it "enqueues multiple Sidekiq jobs" do
+        push!
+
+        expect(redis.llen("queue:default")).to eq(2)
+
+        # reverse is used because Sidekiq enqueues using LPUSH
+        redis.lrange("queue:default", 0, 1).reverse.each_with_index do |job_json, i|
+          expect(JSON.parse(job_json)).to include("class" => "TestJobClass", "args" => args_array[i])
+        end
+      end
+
+      it "returns the count of jobs enqueued" do
+        expect(push!).to eq(2)
+      end
+    end
+
+    context "different jobs" do
+      let(:jobs) do
+        [
+          { class: TestJobClass, args: [1, 2, 3] },
+          { class: OtherTestJobClass, args: [{ "x" => 1 }] },
+        ]
+      end
+      let(:push!) { client.bulk_push(jobs.map(&:stringify_keys)) }
+
+      before do
+        stub_const("OtherTestJobClass", Class.new { include SidekiqPublisher::Worker })
+      end
+
+      it "enqueues multiple Sidekiq jobs" do
+        push!
+
+        expect(redis.llen("queue:default")).to eq(2)
+        redis.lrange("queue:default", 0, 1).reverse.each_with_index do |job_json, i|
+          job = jobs[i]
+          expect(JSON.parse(job_json)).to include("class" => job[:class].to_s, "args" => job[:args])
+        end
+      end
+
+      it "returns the count of jobs enqueued" do
+        expect(push!).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,11 @@ SidekiqPublisher.logger = logger
 
 DATABASE_NAME = "sidekiq_publisher_test"
 
+require "redis-namespace"
+Sidekiq.configure_client do |config|
+  config.redis = { namespace: "sidekiq_publisher_test", url: "redis://localhost:6379" }
+end
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
## What did we change?

Added a subclass of `Sidekiq::Client` that can bulk publish heterogeneous jobs.

## Why are we doing this?

This client will be used to publish a batch of jobs in a single atomic push.

Unfortunately, Sidekiq does not provide an API to do this. Their bulk API only supports any array of args for a single job class. The subclass introduced here therefore relies on a handful of internal methods (`normalize_item`, `process_single`, `atomic_push`).

For right now, I'm targeting the version of Sidekiq that ez-rails is using. Eventually I'll set this up with Appraisals and test against a range of versions that we want to support, but it does not look like these methods have changed between 5.0.x and 5.1.x.

The testing here is fairly minimal right now, but the code here does not make a lot of assumptions about what is passed in as part of a job "item", or what the internal methods do with that hash. Hopefully this provides a baseline that we can hang additional items on as we need to test more specific behavior. 

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
