### PR TITLE
Create rake task to run publisher process [PLAT-92]

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ To use the `SidekiqPublisher`, this can be replaced by including
 `SidekiqPublisher::Worker`. The usual `perform_async`, etc methods will be
 available on the class but jobs will be staged in the Postgres table.
 
+### Running
+
+The publisher process that pulls the job data from postgres and puts them into redis
+can be run with a rake task that is added via railtie for Rails applications:
+
+```bash
+bundle exec rake sidekiq_publisher:publish
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then,

--- a/lib/sidekiq_publisher.rb
+++ b/lib/sidekiq_publisher.rb
@@ -5,6 +5,8 @@ require "sidekiq_publisher/version"
 require "sidekiq_publisher/job"
 require "sidekiq_publisher/worker"
 require "sidekiq_publisher/publisher"
+require "sidekiq_publisher/runner"
+require "sidekiq_publisher/railtie" if defined?(Rails)
 
 module SidekiqPublisher
   DEFAULT_BATCH_SIZE = 100

--- a/lib/sidekiq_publisher/railtie.rb
+++ b/lib/sidekiq_publisher/railtie.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SidekiqPublisher
+  class Railtie < Rails::Railtie
+    rake_tasks do
+      load "sidekiq_publisher/tasks.rake"
+    end
+  end
+end

--- a/lib/sidekiq_publisher/runner.rb
+++ b/lib/sidekiq_publisher/runner.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "activerecord-postgres_pub_sub"
+
+module SidekiqPublisher
+  class Runner
+    extend PrivateAttr
+
+    LISTENER_TIMEOUT_SECONDS = 60
+    CHANNEL_NAME = "sidekiq_publisher_job"
+
+    private_attr_reader :publisher
+
+    def self.run
+      new.run
+    end
+
+    def initialize
+      @publisher = Publisher.new
+    end
+
+    def run
+      ActiveRecord::PostgresPubSub::Listener.listen(
+        CHANNEL_NAME,
+        listen_timeout: LISTENER_TIMEOUT_SECONDS
+      ) do |listener|
+        listener.on_start { publisher.publish }
+        listener.on_notify { publisher.publish }
+        listener.on_timeout { listener_timeout }
+      end
+    end
+
+    private
+
+    def listener_timeout
+      if Job.unpublished.exists?
+        SidekiqPublisher.logger&.warn(
+          "#{self.class.name}: msg='publishing pending jobs at timeout'"
+        )
+        publisher.publish
+      else
+        Job.purge_expired_published!
+      end
+    end
+  end
+end

--- a/lib/sidekiq_publisher/tasks.rake
+++ b/lib/sidekiq_publisher/tasks.rake
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+namespace :sidekiq_publisher do
+  task publish: [:environment] do
+    SidekiqPublisher::Runner.run
+  end
+end

--- a/spec/sidekiq_publisher/runner_spec.rb
+++ b/spec/sidekiq_publisher/runner_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+RSpec.describe SidekiqPublisher::Runner, cleaner_strategy: :truncation do
+  let(:timeout) { 60 }
+  let(:counter) { Hash.new(0) }
+  let(:publisher) { instance_double(SidekiqPublisher::Publisher) }
+  let(:runner_thread) do
+    Thread.new do
+      begin
+        described_class.run
+      ensure
+        ActiveRecord::Base.clear_active_connections!
+      end
+    end
+  end
+
+  before do
+    allow(publisher).to receive(:publish) { counter[:published] += 1 }
+    allow(SidekiqPublisher::Publisher).to receive(:new).and_return(publisher)
+    stub_const("#{described_class}::LISTENER_TIMEOUT_SECONDS", timeout)
+    runner_thread
+  end
+
+  after do
+    runner_thread.terminate
+    runner_thread.join
+  end
+
+  it "publishes when the listener starts" do
+    wait_for("start") { counter[:published] > 0 }
+
+    expect(publisher).to have_received(:publish)
+  end
+
+  it "publishes when the listener is notified" do
+    wait_for("start") { counter[:published] > 0 }
+    create(:publisher_job)
+    wait_for("notify") { counter[:published] > 1 }
+
+    expect(publisher).to have_received(:publish).twice
+  end
+
+  context "when the notification times out" do
+    let(:timeout) { 0.1 }
+
+    before do
+      allow(SidekiqPublisher::Job).to receive(:purge_expired_published!) do
+        counter[:purged] += 1
+      end
+    end
+
+    it "purges old, published jobs" do
+      wait_for("start") { counter[:published] > 0 }
+      wait_for("purge") { counter[:purged] > 0 }
+
+      expect(SidekiqPublisher::Job).to have_received(:purge_expired_published!)
+    end
+
+    context "when there are unpublished jobs" do
+      before do
+        allow(SidekiqPublisher.logger).to receive(:warn)
+        # rubocop:disable RSpec/MessageChain
+        allow(SidekiqPublisher::Job).to receive_message_chain(:unpublished, :exists?).and_return(true)
+        # rubocop:enable RSpec/MessageChain
+      end
+
+      it "publishes unpublished jobs" do
+        wait_for("start") { counter[:published] > 0 }
+        wait_for("timeout") { counter[:published] > 1 }
+
+        expect(SidekiqPublisher::Job).not_to have_received(:purge_expired_published!)
+        expect(publisher).to have_received(:publish).at_least(2).times
+      end
+
+      it "logs a warning message" do
+        wait_for("start") { counter[:published] > 0 }
+        wait_for("timeout") { counter[:published] > 1 }
+
+        expect(SidekiqPublisher.logger).to have_received(:warn).with(
+          "SidekiqPublisher::Runner: msg='publishing pending jobs at timeout'"
+        )
+      end
+    end
+  end
+
+  def wait_for(notification)
+    timeout_at = Time.now + 5
+    loop do
+      return if yield
+      raise "Timed out waiting for #{notification}" if Time.now > timeout_at
+      sleep(0.001)
+    end
+  end
+end


### PR DESCRIPTION
## What did we change?
created a `Runner` class that is called by a rake task so we can run it as a process. also add a railtie to add the rake task automatically

## Why are we doing this?
so we can run this process on a box

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
