### PR TITLE
Configure logger in Railtie

### DIFF
--- a/lib/sidekiq_publisher/railtie.rb
+++ b/lib/sidekiq_publisher/railtie.rb
@@ -5,5 +5,9 @@ module SidekiqPublisher
     rake_tasks do
       load "sidekiq_publisher/tasks.rake"
     end
+
+    initializer "sidekiq_publisher.configure" do
+      SidekiqPublisher.logger = Rails.logger
+    end
   end
 end


### PR DESCRIPTION
## What did we change?

Configured logger for gem as `Rails.logger` in Railtie.

## Why are we doing this?

To provide the gem code with a logger.

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
