### PR TITLE
Update to ezcater_rubocop v0.52.7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,3 @@ inherit_gem:
 Lint/UnneededDisable:
   Exclude:
     - "lib/generators/sidekiq_publisher/templates/create_sidekiq_publisher_jobs.rb"
-
-Style/FrozenStringLiteralComment:
-  Enabled: true
-  EnforcedStyle: always

--- a/sidekiq_publisher.gemspec
+++ b/sidekiq_publisher.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "database_cleaner"
   spec.add_development_dependency "ezcater_matchers" # TODO: this is a private gem
-  spec.add_development_dependency "ezcater_rubocop", "~> 0.52.6"
+  spec.add_development_dependency "ezcater_rubocop", "0.52.7"
   spec.add_development_dependency "factory_bot"
   spec.add_development_dependency "overcommit"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
## What did we change?

Updated to the latest ezcater_rubocop which include `Style/FrozenStringLiteralComment` configuration. Not additional corrections were required.

## Why are we doing this?

Keeping up with the latest style configuration.

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
