### PR TITLE
Report metrics for the number of jobs published and purged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # sidekiq_publisher
 
+## v0.2.0
+- Add metrics for the number of jobs published and purged.
+- Add ActiveSupport as a runtime dependency.
+
 ## v0.1.1
 - Publish Sidekiq jobs with the `created_at` value from when the job was inserted
   into the table.

--- a/README.md
+++ b/README.md
@@ -38,11 +38,26 @@ This gem uses the following configuration:
 
 * **logger**: the logger for this gem to use.
 * **exception_reporter**: a Proc that will be called with an exception
+* **metrics_reporter**: an optional object to record metrics. See below.
 * **batch_size**: the maximum number of jobs that will be enqueued to Sidekiq
   together
 * **job_retention_period**: the duration that published jobs will be kept in
   Postgres after they have been enqueued to Sidekiq
     
+### Metrics Reporter
+
+The metrics reporter that can be configured with an object that is expected to
+respond to the following API:
+
+```ruby
+count(metric_name, count)
+```
+
+Metrics will be reported for:
+
+- the number of jobs published in each batch
+- the number of jobs purged
+
 ## Usage
 
 ### ActiveJob Adapter

--- a/lib/sidekiq_publisher.rb
+++ b/lib/sidekiq_publisher.rb
@@ -13,8 +13,12 @@ module SidekiqPublisher
   DEFAULT_JOB_RETENTION_PERIOD = 1.day.freeze
 
   class << self
-    attr_accessor :logger, :exception_reporter
+    attr_accessor :logger, :exception_reporter, :metrics_reporter
     attr_writer :batch_size, :job_retention_period
+
+    def configure
+      yield self
+    end
 
     def batch_size
       @batch_size || DEFAULT_BATCH_SIZE
@@ -29,6 +33,7 @@ module SidekiqPublisher
       @batch_size = nil
       @job_retention_period = nil
       @exception_reporter = nil
+      @metrics_reporter = nil
     end
   end
 end

--- a/lib/sidekiq_publisher/job.rb
+++ b/lib/sidekiq_publisher/job.rb
@@ -34,6 +34,7 @@ module SidekiqPublisher
       SidekiqPublisher.logger.info("#{name} purging expired published jobs.")
       count = purgeable.delete_all
       SidekiqPublisher.logger.info("#{name} purged #{count} expired published jobs.")
+      SidekiqPublisher.metrics_reporter.try(:count, "sidekiq_publisher:purged", count)
     end
 
     def self.unpublished_batches(batch_size: SidekiqPublisher.batch_size)

--- a/lib/sidekiq_publisher/version.rb
+++ b/lib/sidekiq_publisher/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqPublisher
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end

--- a/sidekiq_publisher.gemspec
+++ b/sidekiq_publisher.gemspec
@@ -9,11 +9,9 @@ Gem::Specification.new do |spec|
   spec.version       = SidekiqPublisher::VERSION
   spec.authors       = ["ezCater, Inc"]
   spec.email         = ["engineering@ezcater.com"]
-
   spec.summary       = "Publisher for enqueuing jobs to Sidekiq"
   spec.description   = spec.summary
   spec.homepage      = "https://github.com/ezcater/sidekiq_publisher"
-
   spec.license       = "MIT"
 
   # Set "allowed_push_post" to control where this gem can be published.
@@ -23,7 +21,6 @@ Gem::Specification.new do |spec|
   else
     raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end
-  # rubocop:enable Style/GuardClause
 
   excluded_files = %w(.circleci/config.yml
                       .github/PULL_REQUEST_TEMPLATE.md
@@ -59,6 +56,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
 
   spec.add_runtime_dependency "activerecord-postgres_pub_sub"
+  spec.add_runtime_dependency "activesupport", "~> 5.1.4"
   spec.add_runtime_dependency "private_attr"
   spec.add_runtime_dependency "sidekiq", "~> 5.0.4"
 end

--- a/spec/sidekiq_publisher/publisher_spec.rb
+++ b/spec/sidekiq_publisher/publisher_spec.rb
@@ -60,6 +60,17 @@ RSpec.describe SidekiqPublisher::Publisher do
       expect(job_model).to have_received(:published!).exactly(2).times
     end
 
+    context "with a metrics reporter configured" do
+      include_context "metrics_reporter context"
+
+      it "records the count of jobs published in each batch" do
+        publisher.publish
+
+        expect(metrics_reporter).to have_received(:try).with(:count, "sidekiq_publisher:published", 2)
+        expect(metrics_reporter).to have_received(:try).with(:count, "sidekiq_publisher:published", 1)
+      end
+    end
+
     context "job retention" do
       let!(:published_job) { create(:published_job) }
       let!(:purgeable_job) { create(:purgeable_job) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,8 @@ require "factory_bot"
 require "shoulda-matchers"
 require "ezcater_matchers"
 
+Dir["#{__dir__}/support/**/*.rb"].sort.each { |f| require f }
+
 logger = Logger.new("log/test.log", level: :debug)
 ActiveRecord::Base.logger = logger
 SidekiqPublisher.logger = logger

--- a/spec/support/contexts/metrics_reporter_context.rb
+++ b/spec/support/contexts/metrics_reporter_context.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+shared_context "metrics_reporter context" do
+  let(:metrics_reporter) { double }
+
+  before do
+    SidekiqPublisher.configure { |config| config.metrics_reporter = metrics_reporter }
+    allow(metrics_reporter).to receive(:try)
+  end
+end


### PR DESCRIPTION
## What did we change?

Added support for recording metrics for the number of jobs published and purged.

Add configuration for an optional metrics reporter.

## Why are we doing this?

Since this is intended to be a public gem, the metrics reporter is optional. For internal use we intend to configure this gem using our internal https://github.com/ezcater/metrics_reporter gem

```ruby
# config/initializers/sidekiq_publisher.rb
SidekiqPublisher.configure do |config
  config.metrics_reporter = MetricsReporter
end
```

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
