### PR TITLE
Add caching for job class lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # sidekiq_publisher
 
+## v0.2.0 (unreleased)
+- Add caching for job class constant lookup.
+
 ## v0.1.1
 - Publish Sidekiq jobs with the `created_at` value from when the job was inserted
   into the table.

--- a/lib/sidekiq_publisher/version.rb
+++ b/lib/sidekiq_publisher/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqPublisher
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end

--- a/spec/sidekiq_publisher/publisher_spec.rb
+++ b/spec/sidekiq_publisher/publisher_spec.rb
@@ -46,6 +46,15 @@ RSpec.describe SidekiqPublisher::Publisher do
       expect(client).to have_received(:bulk_push).with(batch_slices[1])
     end
 
+    it "caches job class lookup" do
+      allow(ActiveSupport::Inflector).to receive(:constantize).and_call_original
+
+      publisher.publish
+
+      expect(ActiveSupport::Inflector).to have_received(:constantize).with("TestJobClass").once
+      expect(ActiveSupport::Inflector).to have_received(:constantize).with("OtherTestJobClass").once
+    end
+
     it "updates the status of each published job" do
       publisher.publish
 


### PR DESCRIPTION
## What did we change?

Added caching for the constantization of job classes in the publisher.

## Why are we doing this?

Constant lookup is a fairly expensive operation and we expect the same job class to be very repetitive.

This change will conflict (in version and CHANGELOG) with another open PR, but I'll resolve conflicts before both are released.

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
