### PR TITLE
Use period as separator in metric names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # sidekiq_publisher
 
+## v0.2.1
+- Use period instead of colon as a separator in metric names.
+
 ## v0.2.0
 - Add caching for job class constant lookup.
 - Add metrics for the number of jobs published and purged.

--- a/lib/sidekiq_publisher/job.rb
+++ b/lib/sidekiq_publisher/job.rb
@@ -34,7 +34,7 @@ module SidekiqPublisher
       SidekiqPublisher.logger.info("#{name} purging expired published jobs.")
       count = purgeable.delete_all
       SidekiqPublisher.logger.info("#{name} purged #{count} expired published jobs.")
-      SidekiqPublisher.metrics_reporter.try(:count, "sidekiq_publisher:purged", count)
+      SidekiqPublisher.metrics_reporter.try(:count, "sidekiq_publisher.purged", count)
     end
 
     def self.unpublished_batches(batch_size: SidekiqPublisher.batch_size)

--- a/lib/sidekiq_publisher/publisher.rb
+++ b/lib/sidekiq_publisher/publisher.rb
@@ -44,7 +44,7 @@ module SidekiqPublisher
       failure_warning(__method__, ex)
     ensure
       published_count = update_jobs_as_published!(batch) if pushed_count.present? && published_count.nil?
-      metrics_reporter.try(:count, "sidekiq_publisher:published", published_count)
+      metrics_reporter.try(:count, "sidekiq_publisher.published", published_count)
     end
 
     def lookup_job_class(name)

--- a/lib/sidekiq_publisher/version.rb
+++ b/lib/sidekiq_publisher/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqPublisher
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/sidekiq_publisher/job_spec.rb
+++ b/spec/sidekiq_publisher/job_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe SidekiqPublisher::Job, type: :model do
 
       it "records a metric for the number of jobs purged" do
         described_class.purge_expired_published!
-        expect(metrics_reporter).to have_received(:try).with(:count, "sidekiq_publisher:purged", 1)
+        expect(metrics_reporter).to have_received(:try).with(:count, "sidekiq_publisher.purged", 1)
       end
     end
   end

--- a/spec/sidekiq_publisher/publisher_spec.rb
+++ b/spec/sidekiq_publisher/publisher_spec.rb
@@ -75,8 +75,8 @@ RSpec.describe SidekiqPublisher::Publisher do
       it "records the count of jobs published in each batch" do
         publisher.publish
 
-        expect(metrics_reporter).to have_received(:try).with(:count, "sidekiq_publisher:published", 2)
-        expect(metrics_reporter).to have_received(:try).with(:count, "sidekiq_publisher:published", 1)
+        expect(metrics_reporter).to have_received(:try).with(:count, "sidekiq_publisher.published", 2)
+        expect(metrics_reporter).to have_received(:try).with(:count, "sidekiq_publisher.published", 1)
       end
     end
 


### PR DESCRIPTION
## What did we change?

The separator used in reported metric names.

## Why are we doing this?

The Datadog statsd client translates colons to underscores.

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
