### PR TITLE
Update to ezcater_rubocop v0.57.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 inherit_gem:
   ezcater_rubocop: conf/rubocop_gem.yml
 
-Lint/UnneededDisable:
+Lint/UnneededCopDisableDirective:
   Exclude:
     - "lib/generators/sidekiq_publisher/templates/create_sidekiq_publisher_jobs.rb"

--- a/sidekiq_publisher.gemspec
+++ b/sidekiq_publisher.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "sidekiq_publisher/version"
 
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "database_cleaner"
   spec.add_development_dependency "ezcater_matchers" # TODO: this is a private gem
-  spec.add_development_dependency "ezcater_rubocop", "0.52.8"
+  spec.add_development_dependency "ezcater_rubocop", "0.57.0"
   spec.add_development_dependency "factory_bot"
   spec.add_development_dependency "overcommit"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/factories/sidekiq_publisher_jobs.rb
+++ b/spec/factories/sidekiq_publisher_jobs.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
           aliases: %i(publisher_job unpublished_job) do
 
     job_id { SidekiqPublisher::Job.generate_sidekiq_jid }
-    job_class { "TestJobClass" }
+    job_class "TestJobClass"
     sequence(:args) { |n| Hash[x: n] }
 
     factory :old_unpublished_job do

--- a/spec/sidekiq_publisher/publisher_spec.rb
+++ b/spec/sidekiq_publisher/publisher_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe SidekiqPublisher::Publisher do
       publisher.publish
 
       # two batches
-      expect(job_model).to have_received(:published!).exactly(2).times
+      expect(job_model).to have_received(:published!).twice
     end
 
     context "with a metrics reporter configured" do

--- a/spec/sidekiq_publisher/runner_spec.rb
+++ b/spec/sidekiq_publisher/runner_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe SidekiqPublisher::Runner, cleaner_strategy: :truncation do
         wait_for("timeout") { counter[:published] > 1 }
 
         expect(SidekiqPublisher::Job).not_to have_received(:purge_expired_published!)
-        expect(publisher).to have_received(:publish).at_least(2).times
+        expect(publisher).to have_received(:publish).at_least(:twice)
       end
 
       it "logs a warning message" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "simplecov"
 SimpleCov.start
 


### PR DESCRIPTION
## What did we change?

Updated the ezcater_rubocop gem.

## Why are we doing this?

To keep up with the latest style rules.

I'm not updating the gem version or changelog as this does not affect any released files. 

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
