### PR TITLE
 Use rubygems in Gemfile and add Circle badge

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# TODO: this should be changed back to rubygems once the activerecord-postgres_pub_sub is public
-source "https://ezcater.jfrog.io/ezcater/api/gems/ezcater-gem-source"
+source "https://rubygems.org"
 
 # override the :github shortcut to be secure by using HTTPS
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # sidekiq_publisher
 
+[![CircleCI](https://circleci.com/gh/ezcater/sidekiq_publisher.svg?style=svg)](https://circleci.com/gh/ezcater/sidekiq_publisher)
+
 This gem provides support to enqueue jobs for Sidekiq by first staging the job
 in Postgres and relying on a separate process to communicate with Sidekiq/Redis.
 

--- a/sidekiq_publisher.gemspec
+++ b/sidekiq_publisher.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "database_cleaner"
-  spec.add_development_dependency "ezcater_matchers" # TODO: this is a private gem
+  spec.add_development_dependency "ezcater_matchers"
   spec.add_development_dependency "ezcater_rubocop", "0.57.0"
   spec.add_development_dependency "factory_bot"
   spec.add_development_dependency "overcommit"


### PR DESCRIPTION
## What did we change?

Use rubygems as the source in Gemfile and add CircleCI badge to README.

## Why are we doing this?

We are open sourcing this project.

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
