### PR TITLE
Index published_at as part of create_table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # sidekiq_publisher
 
+## v0.3.1 (unreleased)
+- Index published_at as part of create table.
+
 ## v0.3.0
 - Add support for Rails 5.2.
 

--- a/lib/generators/sidekiq_publisher/templates/create_sidekiq_publisher_jobs.rb
+++ b/lib/generators/sidekiq_publisher/templates/create_sidekiq_publisher_jobs.rb
@@ -10,11 +10,9 @@ class CreateSidekiqPublisherJobs < ActiveRecord::Migration[5.1]
       t.string :wrapped
       t.json :args, null: false
       t.float :run_at
-      t.timestamp :published_at
+      t.timestamp :published_at, index: true
       t.timestamp :created_at, null: false
     end
     # rubocop:enable Rails/CreateTableWithTimestamps
-
-    add_index(:sidekiq_publisher_jobs, :published_at)
   end
 end

--- a/lib/sidekiq_publisher/version.rb
+++ b/lib/sidekiq_publisher/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqPublisher
-  VERSION = "0.3.0"
+  VERSION = "0.3.1.rc0"
 end


### PR DESCRIPTION
## What did we change?

Added option to index `published_at` as part of table creation.

## Why are we doing this?

Since this is a newly created table this gets around StrongMigrations restrictions on building an index.

## How was it tested?
- [x] Specs
- [x] Locally
- [ ] Staging
