### PR TITLE
Require activerecord-postgres_pub_sub v0.4.0 or later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # sidekiq_publisher
 
+## v0.3.2
+- Require `activerecord-postgres_pub_sub` v0.4.0 or later for
+  strong migrations support.
+
 ## v0.3.1
 - Index published_at as part of create table.
 

--- a/lib/sidekiq_publisher/version.rb
+++ b/lib/sidekiq_publisher/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqPublisher
-  VERSION = "0.3.1"
+  VERSION = "0.3.2"
 end

--- a/sidekiq_publisher.gemspec
+++ b/sidekiq_publisher.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "shoulda-matchers"
   spec.add_development_dependency "simplecov"
 
-  spec.add_runtime_dependency "activerecord-postgres_pub_sub"
+  spec.add_runtime_dependency "activerecord-postgres_pub_sub", ">= 0.4.0"
   spec.add_runtime_dependency "activesupport", ">= 5.1", "< 5.3"
   spec.add_runtime_dependency "private_attr"
   spec.add_runtime_dependency "sidekiq", "~> 5.0.4"


### PR DESCRIPTION
## What did we change?

Added version restriction for a dependency.

## Why are we doing this?

This gem is intended to be compatible with the `strong_migrations` gem, but this dependency also needs to generate compatible migrations.

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
