### PR TITLE
Do not report metric with nil count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # sidekiq_publisher
 
+## v0.3.3
+- Do not report published count metric if it is nil.
+
 ## v0.3.2
 - Require `activerecord-postgres_pub_sub` v0.4.0 or later for
   strong migrations support.

--- a/lib/sidekiq_publisher/publisher.rb
+++ b/lib/sidekiq_publisher/publisher.rb
@@ -44,7 +44,7 @@ module SidekiqPublisher
       failure_warning(__method__, ex)
     ensure
       published_count = update_jobs_as_published!(batch) if pushed_count.present? && published_count.nil?
-      metrics_reporter.try(:count, "sidekiq_publisher.published", published_count)
+      metrics_reporter.try(:count, "sidekiq_publisher.published", published_count) if published_count.present?
     end
 
     def lookup_job_class(name)

--- a/lib/sidekiq_publisher/version.rb
+++ b/lib/sidekiq_publisher/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqPublisher
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end

--- a/spec/sidekiq_publisher/publisher_spec.rb
+++ b/spec/sidekiq_publisher/publisher_spec.rb
@@ -166,6 +166,16 @@ RSpec.describe SidekiqPublisher::Publisher do
 
           expect(job_model.unpublished.pluck(:id)).to match_array(unpublished_jobs.map(&:id))
         end
+
+        context "with a metrics reporter configured" do
+          include_context "metrics_reporter context"
+
+          it "does not record a count of jobs published" do
+            publisher.publish
+
+            expect(metrics_reporter).not_to have_received(:try)
+          end
+        end
       end
 
       context "when an error is raised while marking jobs as published" do


### PR DESCRIPTION
## What did we change?

Stopped attempting to record a metric for the number of published jobs when the value is nil.

## Why are we doing this?

To eliminate a Sentry: https://sentry.io/ezcater/ez-rails/issues/654482494/?environment=production

If an error occurs during publishing and no jobs are pushed to Redis, then there will not be a count to record.

We treat Sentries like bugs and should work to eliminate them, or record them by other means if they are expected errors.

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
