### PR TITLE
Preserve Sidekiq::Worker.client_push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # sidekiq_publisher
 
 ## v1.4.0 (unreleased)
-- Preserve access to `Sidekiq::Worker`'s `#client_push` method.
+- Preserve access to `Sidekiq::Worker`'s `.client_push` method.
 
 ## v1.3.0
 - Extend support to Rails 6.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # sidekiq_publisher
 
+## v1.4.0 (unreleased)
+- Preserve access to `Sidekiq::Worker`'s `#client_push` method.
+
 ## v1.3.0
 - Extend support to Rails 6.0.
 

--- a/lib/sidekiq_publisher/version.rb
+++ b/lib/sidekiq_publisher/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqPublisher
-  VERSION = "1.3.0"
+  VERSION = "1.4.0.rc0"
 end

--- a/lib/sidekiq_publisher/worker.rb
+++ b/lib/sidekiq_publisher/worker.rb
@@ -4,6 +4,7 @@ module SidekiqPublisher
   module Worker
     def self.included(base)
       base.include(Sidekiq::Worker)
+      base.singleton_class.public_send(:alias_method, :sidekiq_client_push, :client_push)
       base.extend(ClassMethods)
     end
 


### PR DESCRIPTION
## What did we change?

Aliased Sidekiq's original `.client_push` method.

## Why are we doing this?

This gem overrides the `.client_push` method for a worker, but I have a use case with the https://github.com/mhenrixon/sidekiq-unique-jobs gem where the job is first enqueued using `sidekiq_publisher` but then we want to reschedule directly within Sidekiq.

## How was it tested?
- [x] Specs
- [x] Locally
- [ ] Staging
