### PR TITLE
Support Sidekiq::Testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # sidekiq_publisher
 
+## v1.6.0 (unreleased)
+- Support `Sidekiq::Testing` modes. This only applies to `SidekiqPublisher::Worker`
+  and not the `ActiveJob` adapter.
+
 ## v1.5.0
 - Expand sidekiq support to v5.0.x-v6.0.x.
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,31 @@ can be run with a rake task that is added via Railtie for Rails applications:
 bundle exec rake sidekiq_publisher:publish
 ```
 
+## Testing
+
+### Sidekiq
+
+When using sidekiq_publisher directly with Sidekiq workers, the testing modes
+provided by Sidekiq are supported.
+
+Require the `sidekiq_publisher/testing` file. (This should only be done in test!)
+
+```ruby
+require "sidekiq_publisher/testing"
+```
+
+This file requires "sidekiq/testing" so there is no need to explictly require both.
+Note that by default, Sidekiq sets the test mode to `fake` and stores jobs in a
+`jobs` array for each worker class.
+
+To have `SidekiqPublisher` continue to insert jobs into a table within tests
+call `Sidekiq::Testing.disable!`.
+
+### ActiveJob
+
+When using the sidekiq_publisher adapter for `ActiveJob`, use the `ActiveJob`
+test adapter if you want to run jobs inline during tests.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then,

--- a/lib/sidekiq_publisher/job.rb
+++ b/lib/sidekiq_publisher/job.rb
@@ -18,6 +18,15 @@ module SidekiqPublisher
     scope :published, -> { where.not(published_at: nil) }
     scope :purgeable, -> { where("published_at < ?", Time.now.utc - job_retention_period) }
 
+    def self.create_job!(item)
+      create!(
+        job_class: item["class"].to_s,
+        args: item["args"],
+        run_at: item["at"],
+        queue: item["queue"]
+      )
+    end
+
     def self.generate_sidekiq_jid
       SecureRandom.hex(12)
     end

--- a/lib/sidekiq_publisher/testing.rb
+++ b/lib/sidekiq_publisher/testing.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "sidekiq_publisher"
+require "sidekiq/testing"
+
+module SidekiqPublisher
+  module Testing
+    def self.prepended(base)
+      base.singleton_class.public_send(:alias_method, :original_create_job!, :create_job!)
+      base.singleton_class.prepend(ClassMethods)
+    end
+
+    module ClassMethods
+      def create_job!(item)
+        if Sidekiq::Testing.enabled?
+          item["class"].sidekiq_client_push(item)
+        else
+          original_create_job!(item)
+        end
+      end
+    end
+  end
+end
+
+SidekiqPublisher::Job.prepend(SidekiqPublisher::Testing)

--- a/lib/sidekiq_publisher/version.rb
+++ b/lib/sidekiq_publisher/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqPublisher
-  VERSION = "1.5.0"
+  VERSION = "1.6.0.pre0"
 end

--- a/lib/sidekiq_publisher/worker.rb
+++ b/lib/sidekiq_publisher/worker.rb
@@ -10,12 +10,7 @@ module SidekiqPublisher
 
     module ClassMethods
       def client_push(item)
-        SidekiqPublisher::Job.create!(
-          job_class: item["class"].to_s,
-          args: item["args"],
-          run_at: item["at"],
-          queue: item["queue"]
-        )
+        SidekiqPublisher::Job.create_job!(item)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ require "simplecov"
 SimpleCov.start
 
 require "active_job"
-require "sidekiq_publisher"
+require "sidekiq_publisher/testing"
 require "active_job/queue_adapters/sidekiq_publisher_adapter"
 
 require "database_cleaner"
@@ -18,6 +18,8 @@ Dir["#{__dir__}/support/**/*.rb"].sort.each { |f| require f }
 logger = Logger.new("log/test.log", level: :debug)
 ActiveRecord::Base.logger = logger
 SidekiqPublisher.logger = logger
+
+Sidekiq::Testing.disable!
 
 DATABASE_NAME = "sidekiq_publisher_test"
 


### PR DESCRIPTION
## What did we change?

Added support for Sidekiq test modes when using `SidekiqPublisher::Worker`.

## Why are we doing this?

To better support tests where jobs need to execute inline.

This change takes a similar approach to Sidekiq, modifying the way that jobs are enqueued when the `sidekiq_publisher/testing` file is included. 

The Sidekiq test mode support does not extend to the ActiveJob adapter. That can probably also be made to work with a few additional changes. I don't know if people use the standard ActiveJob Sidekiq adapter with different Sidekiq test modes or if they instead use ActiveJob test adapters.

This should be tested with a pre-release before an official release is cut.

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
