### PR TITLE
Replace a couple of private_attr uses and remove the gem dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # sidekiq_publisher
 
+## v1.6.1 (unreleased)
+- Remove the `private_attr` top-level gem dependency.
+
 ## v1.6.0
 - Support `Sidekiq::Testing` modes. This only applies to `SidekiqPublisher::Worker`
   and not the `ActiveJob` adapter.

--- a/lib/sidekiq_publisher.rb
+++ b/lib/sidekiq_publisher.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "private_attr"
 require "sidekiq_publisher/version"
 require "sidekiq_publisher/report_unpublished_count"
 require "sidekiq_publisher/job"

--- a/lib/sidekiq_publisher/publisher.rb
+++ b/lib/sidekiq_publisher/publisher.rb
@@ -5,10 +5,6 @@ require "active_support/core_ext/object/try"
 
 module SidekiqPublisher
   class Publisher
-    extend PrivateAttr
-
-    private_attr_reader :client, :job_class_cache
-
     def initialize
       @client = SidekiqPublisher::Client.new
       @job_class_cache = {}
@@ -36,6 +32,8 @@ module SidekiqPublisher
     end
 
     private
+
+    attr_reader :client, :job_class_cache
 
     def publish_batch(batch, items)
       pushed_count = client.bulk_push(items)

--- a/lib/sidekiq_publisher/runner.rb
+++ b/lib/sidekiq_publisher/runner.rb
@@ -4,12 +4,8 @@ require "activerecord-postgres_pub_sub"
 
 module SidekiqPublisher
   class Runner
-    extend PrivateAttr
-
     LISTENER_TIMEOUT_SECONDS = 60
     CHANNEL_NAME = "sidekiq_publisher_job"
-
-    private_attr_reader :publisher
 
     def self.run
       new.run
@@ -31,6 +27,8 @@ module SidekiqPublisher
     end
 
     private
+
+    attr_reader :publisher
 
     def listener_timeout
       if Job.unpublished.exists?

--- a/sidekiq_publisher.gemspec
+++ b/sidekiq_publisher.gemspec
@@ -58,6 +58,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "activerecord-postgres_pub_sub", ">= 0.4.0"
   spec.add_runtime_dependency "activesupport", ">= 5.1", "< 6.1"
-  spec.add_runtime_dependency "private_attr"
   spec.add_runtime_dependency "sidekiq", ">= 5.0.4", "< 6.1"
 end


### PR DESCRIPTION
## What did we change?

Two instances of `private_attr_reader` are replaced, and the top-level `private_attr` gem dependency is removed.

## Why are we doing this?

We only use this gem in 2 places, the warning the gem aims to address ("private attribute?") was [removed in Ruby 2.3.0](https://bugs.ruby-lang.org/issues/10967), and removing the dependency seems worth it.

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
