### PR TITLE
Gracefully handle `INT` and `TERM` process signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # sidekiq_publisher
 
+## (Unreleased)
+- Gracefully respond to `INT` and `TERM` process signals.
+
 ## v1.6.1
 - Remove the `private_attr` top-level gem dependency.
 

--- a/lib/sidekiq_publisher/tasks.rake
+++ b/lib/sidekiq_publisher/tasks.rake
@@ -2,6 +2,9 @@
 
 namespace :sidekiq_publisher do
   task publish: [:environment] do
+    Signal.trap("INT") { exit(0) }
+    Signal.trap("TERM") { exit(0) }
+
     SidekiqPublisher::Runner.run
   end
 end


### PR DESCRIPTION
## What did we change?

`rake sidekiq_publisher:publish` now gracefully responds to the `INT` and `TERM` process signals.

## Why are we doing this?

Before this change, when `rake sidekiq_publisher:publisher` was terminated via `INT` (i.e. CTRL+C in a terminal window) or via `TERM` (i.e. via a process manager like Kubernetes or Heroku's Dyno Manager), it would exit `1` with something like this:

```
rake aborted!
Interrupt:
/usr/local/var/rbenv/versions/2.6.3/bin/bundle:23:in `load'
/usr/local/var/rbenv/versions/2.6.3/bin/bundle:23:in `<main>'
Tasks: TOP => sidekiq_publisher:publish
(See full trace by running task with --trace)
```

Exiting with a non-`0` exit code is not ideal, since sidekiq_publisher (technically its underlying dependency activerecord-postgres_pub_sub) does clean up after itself upon exit by executing an `UNLISTEN`, which is all the cleanup that's necessary! This can skew process exit metrics. Additionally, the exception output results in some dirtier logs.

It's worth noting that the `UNLISTEN` is executed due to it being in an [`ensure`](https://github.com/ezcater/activerecord-postgres_pub_sub/blob/v1.1.0/lib/activerecord/postgres_pub_sub/listener.rb#L63-L65) block, which is invoked due to Ruby raising an `Interrupt` or `SignalException` exception when it receives `INT` or `TERM` signals. In the future, it might make sense for the process shutdown workflow to be supported more explicitly, but since there is currently no other cleanup necessary besides an `UNLISTEN`, the change seems unecessary for the timebeing.

## How was it tested?
- [ ] Specs
- [x] Locally
- [ ] Staging
