### PR TITLE
Handle client middleware that returns false

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
           command: |
             ./cc-test-reporter before-build
             bundle exec appraisal rails-5.2-sidekiq-5.2 rspec --format RspecJunitFormatter --format progress
-            ./cc-test-reporter after-build -t simplecov --exit-code $?
+            ./cc-test-reporter after-build -t simplecov --exit-code $? || exit 0
 
       - run:
           name: rails-5.2-sidekiq-6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # sidekiq_publisher
 
+## v1.6.3
+- Handle client middleware that returns false.
+
 ## v1.6.2
 - Gracefully respond to `INT` and `TERM` process signals.
 

--- a/lib/sidekiq_publisher/client.rb
+++ b/lib/sidekiq_publisher/client.rb
@@ -7,7 +7,7 @@ module SidekiqPublisher
     def bulk_push(items)
       payloads = items.map do |item|
         normed = normalize_item(item)
-        process_single(item["class"], normed)
+        process_single(item["class"], normed) || nil
       end.compact
 
       pushed = 0

--- a/lib/sidekiq_publisher/version.rb
+++ b/lib/sidekiq_publisher/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqPublisher
-  VERSION = "1.6.2"
+  VERSION = "1.6.3"
 end

--- a/sidekiq_publisher.gemspec
+++ b/sidekiq_publisher.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "rspec_junit_formatter", "0.2.2"
   spec.add_development_dependency "shoulda-matchers"
-  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "simplecov", "< 0.18"
 
   spec.add_runtime_dependency "activerecord-postgres_pub_sub", ">= 0.4.0"
   spec.add_runtime_dependency "activesupport", ">= 5.1", "< 6.1"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,9 +22,10 @@ SidekiqPublisher.logger = logger
 Sidekiq::Testing.disable!
 
 DATABASE_NAME = "sidekiq_publisher_test"
+REDIS_URL = ENV.fetch("REDIS_URL", "redis://localhost:6379")
 
 Sidekiq.configure_client do |config|
-  config.redis = { namespace: "sidekiq_publisher_test", url: "redis://localhost:6379" }
+  config.redis = { namespace: "sidekiq_publisher_test", url: REDIS_URL }
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
## What did we change?

If process_single, which invokes client middleware, return false then treat it as nil.

## Why are we doing this?

Inspired by this line: https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/client.rb#L107

Middleware that returned `false` was previously being treated as a job resulting in an error.

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
