### PR TITLE
Instrument using ActiveSupport::Notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # sidekiq_publisher
 
+## v1.7.0 (unreleased)
+- Add instrumentation using `ActiveSupport::Notifications`.
+
 ## v1.6.4
 - Expand sidekiq support to v5.0.x-v6.x.x.
 

--- a/lib/sidekiq_publisher.rb
+++ b/lib/sidekiq_publisher.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
+require "active_support"
 require "sidekiq_publisher/version"
+require "sidekiq_publisher/instrumenter"
 require "sidekiq_publisher/report_unpublished_count"
 require "sidekiq_publisher/job"
 require "sidekiq_publisher/worker"

--- a/lib/sidekiq_publisher/instrumenter.rb
+++ b/lib/sidekiq_publisher/instrumenter.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module SidekiqPublisher
+  class Instrumenter
+    NAMESPACE = "sidekiq_publisher"
+
+    def initialize
+      @backend = if defined?(ActiveSupport::Notifications)
+                   ActiveSupport::Notifications
+                 end
+    end
+
+    def instrument(event_name, payload = {}, &block)
+      if backend
+        backend.instrument("#{event_name}.#{NAMESPACE}", payload, &block)
+      else
+        yield(payload) if block
+      end
+    end
+
+    private
+
+    attr_reader :backend
+  end
+end

--- a/lib/sidekiq_publisher/instrumenter.rb
+++ b/lib/sidekiq_publisher/instrumenter.rb
@@ -13,8 +13,8 @@ module SidekiqPublisher
     def instrument(event_name, payload = {}, &block)
       if backend
         backend.instrument("#{event_name}.#{NAMESPACE}", payload, &block)
-      else
-        yield(payload) if block
+      elsif block
+        yield(payload)
       end
     end
 

--- a/lib/sidekiq_publisher/publisher.rb
+++ b/lib/sidekiq_publisher/publisher.rb
@@ -73,7 +73,7 @@ module SidekiqPublisher
       logger.warn("#{self.class.name}: msg=\"#{method} failed\" error=#{ex.class} error_msg=#{ex.message.inspect}\n")
       SidekiqPublisher.exception_reporter&.call(ex)
       instrumenter.instrument("error.publisher",
-                              { exception_object: ex, exception: [ex.class.name, ex.message] })
+                              exception_object: ex, exception: [ex.class.name, ex.message])
     end
 
     def logger

--- a/lib/sidekiq_publisher/publisher.rb
+++ b/lib/sidekiq_publisher/publisher.rb
@@ -5,26 +5,31 @@ require "active_support/core_ext/object/try"
 
 module SidekiqPublisher
   class Publisher
-    def initialize
+    def initialize(instrumenter: Instrumenter.new)
+      @instrumenter = instrumenter
       @client = SidekiqPublisher::Client.new
       @job_class_cache = {}
     end
 
     def publish
       Job.unpublished_batches do |batch|
-        items = batch.map do |job|
-          {
-            "jid" => job[:job_id],
-            "class" => lookup_job_class(job[:job_class]),
-            "args" => job[:args],
-            "at" => job[:run_at],
-            "queue" => job[:queue],
-            "wrapped" => job[:wrapped],
-            "created_at" => job[:created_at].to_f,
-          }.tap(&:compact!)
-        end
+        instrumenter.instrument("publish_batch.publisher") do
+          items = batch.map do |job|
+            {
+              "jid" => job[:job_id],
+              "class" => lookup_job_class(job[:job_class]),
+              "args" => job[:args],
+              "at" => job[:run_at],
+              "queue" => job[:queue],
+              "wrapped" => job[:wrapped],
+              "created_at" => job[:created_at].to_f,
+            }.tap(&:compact!)
+          end
 
-        publish_batch(batch, items)
+          instrumenter.instrument("enqueue_batch.publisher") do |notification|
+            enqueue_batch(batch, items, notification)
+          end
+        end
       end
       purge_expired_published_jobs
     rescue StandardError => ex
@@ -33,15 +38,16 @@ module SidekiqPublisher
 
     private
 
-    attr_reader :client, :job_class_cache
+    attr_reader :client, :job_class_cache, :instrumenter
 
-    def publish_batch(batch, items)
+    def enqueue_batch(batch, items, notification)
       pushed_count = client.bulk_push(items)
       published_count = update_jobs_as_published!(batch)
     rescue StandardError => ex
       failure_warning(__method__, ex)
     ensure
       published_count = update_jobs_as_published!(batch) if pushed_count.present? && published_count.nil?
+      notification[:published_count] = published_count if published_count.present?
       metrics_reporter.try(:count, "sidekiq_publisher.published", published_count) if published_count.present?
     end
 
@@ -56,7 +62,7 @@ module SidekiqPublisher
     end
 
     def purge_expired_published_jobs
-      Job.purge_expired_published! if perform_purge?
+      Job.purge_expired_published!(instrumenter: instrumenter) if perform_purge?
     end
 
     def perform_purge?
@@ -64,9 +70,10 @@ module SidekiqPublisher
     end
 
     def failure_warning(method, ex)
-      logger.warn("#{self.class.name}: msg=\"#{method} failed\" error=#{ex.class} error_msg=#{ex.message.inspect}\n"\
-                  "#{ex.backtrace.join("\n")}")
+      logger.warn("#{self.class.name}: msg=\"#{method} failed\" error=#{ex.class} error_msg=#{ex.message.inspect}\n")
       SidekiqPublisher.exception_reporter&.call(ex)
+      instrumenter.instrument("error.publisher",
+                              { exception_object: ex, exception: [ex.class.name, ex.message] })
     end
 
     def logger

--- a/lib/sidekiq_publisher/version.rb
+++ b/lib/sidekiq_publisher/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqPublisher
-  VERSION = "1.6.4"
+  VERSION = "1.7.0"
 end

--- a/spec/sidekiq_publisher/instrumenter_spec.rb
+++ b/spec/sidekiq_publisher/instrumenter_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe SidekiqPublisher::Instrumenter do
+RSpec.describe SidekiqPublisher::Instrumenter, skip_db_clean: true do
   let(:instrumenter) { described_class.new }
   let(:payload) { Hash.new[a: 1] }
 

--- a/spec/sidekiq_publisher/instrumenter_spec.rb
+++ b/spec/sidekiq_publisher/instrumenter_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe SidekiqPublisher::Instrumenter do
+  let(:instrumenter) { described_class.new }
+  let(:payload) { Hash.new[a: 1] }
+
+  context "when ActiveSupport::Notifications is defined" do
+    describe "#instrument" do
+      before do
+        allow(ActiveSupport::Notifications).to receive(:instrument).and_call_original
+      end
+
+      it "calls instrument on ActiveSupport::Notifications" do
+        instrumenter.instrument("foo", payload)
+
+        expect(ActiveSupport::Notifications).to have_received(:instrument).
+          with("foo.sidekiq_publisher", payload)
+      end
+
+      context "with a block" do
+        it "calls the block with the payload" do
+          expect do |blk|
+            instrumenter.instrument("foo", payload, &blk)
+          end.to yield_with_args(payload)
+        end
+      end
+    end
+  end
+
+  context "when ActiveSupport::Notifications is not defined" do
+    before do
+      hide_const("ActiveSupport::Notifications")
+    end
+
+    it "is a no-op" do
+      instrumenter.instrument("foo", payload)
+    end
+
+    context "with a block" do
+      it "calls the block with the payload" do
+        expect do |blk|
+          instrumenter.instrument("foo", payload, &blk)
+        end.to yield_with_args(payload)
+      end
+    end
+  end
+end

--- a/spec/sidekiq_publisher/publisher_spec.rb
+++ b/spec/sidekiq_publisher/publisher_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe SidekiqPublisher::Publisher do
           publisher.publish
 
           expect(instrumenter).to have_received(:instrument).
-            with("error.publisher", { exception_object: error, exception: [error.class.name, error.message]})
+            with("error.publisher", exception_object: error, exception: [error.class.name, error.message])
         end
 
         it "does not update any jobs as published" do
@@ -186,7 +186,7 @@ RSpec.describe SidekiqPublisher::Publisher do
           publisher.publish
 
           expect(instrumenter).to have_received(:instrument).
-            with("error.publisher", { exception_object: error, exception: [error.class.name, error.message]})
+            with("error.publisher", exception_object: error, exception: [error.class.name, error.message])
         end
 
         it "does not update any jobs as published" do
@@ -242,7 +242,7 @@ RSpec.describe SidekiqPublisher::Publisher do
           publisher.publish
 
           expect(instrumenter).to have_received(:instrument).
-            with("error.publisher", { exception_object: error, exception: [error.class.name, error.message]})
+            with("error.publisher", exception_object: error, exception: [error.class.name, error.message])
         end
 
         it "updates the status of each published job" do

--- a/spec/sidekiq_publisher/publisher_spec.rb
+++ b/spec/sidekiq_publisher/publisher_spec.rb
@@ -2,10 +2,12 @@
 
 RSpec.describe SidekiqPublisher::Publisher do
   let(:client) { instance_double(SidekiqPublisher::Client) }
-  let(:publisher) { described_class.new }
+  let(:publisher) { described_class.new(instrumenter: instrumenter) }
   let(:test_job_class) { Class.new { include SidekiqPublisher::Worker } }
   let(:buffer) { Array.new }
   let(:job_model) { SidekiqPublisher::Job }
+  let(:instrumenter) { instance_double(SidekiqPublisher::Instrumenter) }
+  let(:payload) { Hash.new }
 
   before do
     stub_const("TestJobClass", test_job_class)
@@ -14,6 +16,10 @@ RSpec.describe SidekiqPublisher::Publisher do
     allow(client).to receive(:bulk_push) do |items|
       buffer << items
     end
+    allow(instrumenter).to receive(:instrument).and_yield(Hash.new)
+    allow(instrumenter).to receive(:instrument).with("error.publisher", instance_of(Hash)) # no yield
+    allow(instrumenter).to receive(:instrument).with("publish_batch.publisher").and_yield
+    allow(instrumenter).to receive(:instrument).with("enqueue_batch.publisher").and_yield(payload)
   end
 
   describe "#publish" do
@@ -67,6 +73,14 @@ RSpec.describe SidekiqPublisher::Publisher do
 
       # two batches
       expect(job_model).to have_received(:published!).twice
+    end
+
+    it "instruments publish activity" do
+      publisher.publish
+
+      expect(instrumenter).to have_received(:instrument).with("publish_batch.publisher").twice
+      expect(instrumenter).to have_received(:instrument).with("enqueue_batch.publisher").twice
+      expect(payload[:published_count]).to eq(1)
     end
 
     context "with a metrics reporter configured" do
@@ -131,6 +145,13 @@ RSpec.describe SidekiqPublisher::Publisher do
           expect(exception_reporter).to have_received(:call).with(error)
         end
 
+        it "instruments the error" do
+          publisher.publish
+
+          expect(instrumenter).to have_received(:instrument).
+            with("error.publisher", { exception_object: error, exception: [error.class.name, error.message]})
+        end
+
         it "does not update any jobs as published" do
           publisher.publish
 
@@ -159,6 +180,13 @@ RSpec.describe SidekiqPublisher::Publisher do
           publisher.publish
 
           expect(exception_reporter).to have_received(:call).with(error)
+        end
+
+        it "instruments the error" do
+          publisher.publish
+
+          expect(instrumenter).to have_received(:instrument).
+            with("error.publisher", { exception_object: error, exception: [error.class.name, error.message]})
         end
 
         it "does not update any jobs as published" do
@@ -208,6 +236,13 @@ RSpec.describe SidekiqPublisher::Publisher do
           publisher.publish
 
           expect(exception_reporter).to have_received(:call).with(error)
+        end
+
+        it "instruments the error" do
+          publisher.publish
+
+          expect(instrumenter).to have_received(:instrument).
+            with("error.publisher", { exception_object: error, exception: [error.class.name, error.message]})
         end
 
         it "updates the status of each published job" do

--- a/spec/sidekiq_publisher/runner_spec.rb
+++ b/spec/sidekiq_publisher/runner_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SidekiqPublisher::Runner, cleaner_strategy: :truncation do
   let(:timeout) { 60 }
   let(:counter) { Hash.new(0) }
   let(:publisher) { instance_double(SidekiqPublisher::Publisher) }
-  let(:instrumenter) { instance_double(SidekiqPublisher::Instrumenter)}
+  let(:instrumenter) { instance_double(SidekiqPublisher::Instrumenter) }
   let(:runner_thread) do
     Thread.new do
       described_class.run(instrumenter)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "simplecov"
 SimpleCov.start
 
+require "active_support/notifications"
+
 require "active_job"
 require "sidekiq_publisher/testing"
 require "active_job/queue_adapters/sidekiq_publisher_adapter"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -78,12 +78,14 @@ RSpec.configure do |config|
   end
 
   config.before do |example|
-    DatabaseCleaner.strategy = example.metadata.fetch(:cleaner_strategy, :transaction)
-    DatabaseCleaner.start
+    unless example.metadata.fetch(:skip_db_clean, false)
+      DatabaseCleaner.strategy = example.metadata.fetch(:cleaner_strategy, :transaction)
+      DatabaseCleaner.start
+    end
   end
 
-  config.after do
-    DatabaseCleaner.clean
+  config.after do |example|
+    DatabaseCleaner.clean unless example.metadata.fetch(:skip_db_clean, false)
   end
 end
 


### PR DESCRIPTION
## What did we change?

Added instrumentation using ActiveSupport::Notifications.

## Why are we doing this?

This change lays the groundwork for supporting APM tracing in this library.

Since this is an open source library, we do not assume use of a specific APM product. An upcoming change will add optional, example tracing using Datadog APM based on this instrumentation. 

Documentation will be added when the examples based on instrumentation are added.

The existing `metrics_reporter` and `exception_reporter` in this gem will also be refactored to use this instrumentation in the later change.

Using ActiveSupport::Notifications in this way provides an easy way for any users of this library to subscribe to notifications and integrate with monitoring/logging/tracing solutions they are using.

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
