### PR TITLE
Add docker-compose configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,11 @@ jobs:
         environment:
           - PGHOST: 127.0.0.1
           - PGUSER: postgres
-      - image: circleci/postgres:9.6.8
+      - image: circleci/postgres:11.6
         environment:
           - POSTGRES_USER: postgres
           - POSTGRES_DB: sidekiq_publisher_test
-      - image: redis:2.8
+      - image: redis:5.0
     steps:
       - checkout
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM ezcater-production.jfrog.io/ruby:f08726283c
+RUN mkdir /usr/src/gem
+WORKDIR /usr/src/gem
+ADD . /usr/src/gem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3.4"
+volumes:
+  bundle-volume:
+  shared-volume:
+x-environment: &default-environment
+  PRYRC: /usr/src/app/.docker-pryrc
+  BUNDLE_IGNORE_CONFIG: 1
+  BUNDLE_DISABLE_SHARED_GEMS: "true"
+  PGUSER: postgres
+  PGHOST: sidekiq-publisher-postgres
+  PGPORT: 5432
+  PGDATABASE: sidekiq_publisher_test
+  REDIS_URL: redis://sidekiq-publisher-redis:6379
+x-service: &default-service
+  build:
+    context: .
+    args:
+      - BUNDLE_EZCATER__JFROG__IO
+  volumes:
+    - .:/usr/src/gem
+    - bundle-volume:/usr/local/bundle:delegated
+    - shared-volume:/usr/src/shared:delegated
+  tty: true
+  stdin_open: true
+services:
+  sidekiq-publisher-redis:
+    container_name: sidekiq-publisher-redis_1
+    image: redis:5.0.3-alpine
+  sidekiq-publisher-postgres:
+    container_name: sidekiq-publisher-postgres_1
+    image: postgres:10.6
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: sidekiq_publisher_test
+  sidekiq-publisher-console:
+    <<: *default-service
+    container_name: sidekiq-publisher-console_1
+    environment:
+      <<: *default-environment
+    command: bash
+    depends_on:
+      - sidekiq-publisher-redis
+      - sidekiq-publisher-postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,10 +25,10 @@ x-service: &default-service
 services:
   sidekiq-publisher-redis:
     container_name: sidekiq-publisher-redis_1
-    image: redis:5.0.3-alpine
+    image: redis:5.0.9-alpine
   sidekiq-publisher-postgres:
     container_name: sidekiq-publisher-postgres_1
-    image: postgres:10.6
+    image: postgres:11.6
     environment:
       POSTGRES_USER: postgres
       POSTGRES_DB: sidekiq_publisher_test


### PR DESCRIPTION
## What did we change?

Added docker-compose configuration.

Update versions used to test.

## Why are we doing this?

Having docker-compose configuration makes it easier to develop this gem locally without having to natively install Redis and Postgres.

Using an ezCater ruby image is a convenience and should be replaced to make this more useful publicly.

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
