### PR TITLE
Instrument using subscribers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v1.7.0 (unreleased)
 - Add instrumentation using `ActiveSupport::Notifications`.
+- Reimplement `metrics_reporter` and `exception_reporter` support using
+  `ActiveSupport::Subscriber`.
+- Add optional integration with Datadog APM.
 
 ## v1.6.4
 - Expand sidekiq support to v5.0.x-v6.x.x.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,34 @@ SidekiqPublisher::ReportUnpublishedCount.call
 It is recommended to call this method periodically using something like
 cron or [clockwork](https://github.com/Rykian/clockwork).
 
+## Instrumentation
+
+Instrumentation of this library is implemented using
+[ActiveSupport::Notifications](https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html).
+
+The support for the configurable [metrics_reporter](lib/sidekiq_publisher/metrics_reporter.rb) and
+[exception_reporter](lib/sidekiq_publisher/exception_reporter.rb) options is implemented using
+[ActiveSupport::Subscriber](https://api.rubyonrails.org/classes/ActiveSupport/Subscriber.html).
+
+If an alternate integration is required for metrics or error reporting then it can be implemented using outside this
+library based on these examples.
+
+### Tracing
+
+The instrumentation in the library also supports integration with application tracing products, such as
+[Datadog APM](https://www.datadoghq.com/product/apm/).
+
+There is an optional integration with Datadog APM that can be required:
+
+```ruby
+require "sidekiq_publisher/datadog_apm"
+```
+
+This file must be required in addition including the `sidekiq_publisher` gem or requiring `sidekiq_publisher`.
+
+This integration covers all of the sections of the library that are instrumented and serves an
+[example](lib/sidekiq_publisher/datadog_apm) for implementing trace reporting for other products outside this library.
+
 ## Usage
 
 ### ActiveJob Adapter

--- a/lib/sidekiq_publisher.rb
+++ b/lib/sidekiq_publisher.rb
@@ -3,6 +3,8 @@
 require "active_support"
 require "sidekiq_publisher/version"
 require "sidekiq_publisher/instrumenter"
+require "sidekiq_publisher/metrics_reporter"
+require "sidekiq_publisher/exception_reporter"
 require "sidekiq_publisher/report_unpublished_count"
 require "sidekiq_publisher/job"
 require "sidekiq_publisher/worker"

--- a/lib/sidekiq_publisher/datadog_apm.rb
+++ b/lib/sidekiq_publisher/datadog_apm.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "active_support/subscriber"
+require "ddtrace"
+
+module SidekiqPublisher
+  module DatadogAPM
+    OPERATION = "sidekiq_publisher"
+
+    class << self
+      attr_writer :service
+
+      def service
+        @service || "sidekiq-publisher"
+      end
+    end
+
+    class Subscriber
+      def self.subscribe_to(pattern)
+        ActiveSupport::Notifications.subscribe(pattern, new)
+      end
+
+      def finish(_name, _id, payload)
+        finish_span(payload)
+      end
+
+      private
+
+      def start_span(operation, payload, resource = nil)
+        resource ||= operation
+        payload[:datadog_span] = Datadog.tracer.trace(operation, service: service, resource: resource)
+      end
+
+      def start_primary_span(resource, payload)
+        start_span(OPERATION, payload, resource)
+      end
+
+      def finish_span(payload)
+        payload[:datadog_span]&.set_error(payload[:exception_object]) if payload.key?(:exception_object)
+        payload[:datadog_span]&.finish
+      end
+
+      def service
+        SidekiqPublisher::DatadogAPM.service
+      end
+    end
+
+    class ListenerSubscriber < Subscriber
+      def start(_name, _id, payload)
+        start_primary_span("listener.timeout", payload)
+      end
+
+      subscribe_to "timeout.listener.sidekiq_publisher"
+    end
+
+    class RunnerSubscriber < Subscriber
+      def start(name, _id, payload)
+        op_name = name.split(".").first
+        start_primary_span("publisher.#{op_name}", payload)
+      end
+
+      subscribe_to "start.publisher.sidekiq_publisher"
+      subscribe_to "notify.publisher.sidekiq_publisher"
+      subscribe_to "timeout.publisher.sidekiq_publisher"
+    end
+
+    class PublisherSubscriber < Subscriber
+      def start(name, _id, payload)
+        op_name = name.split(".").first
+        start_span("publisher.#{op_name}", payload)
+      end
+
+      def finish(name, id, payload)
+        payload[:datadog_span]&.set_tag(:published_count, payload[:published_count]) if payload.key?(:published_count)
+        super
+      end
+
+      subscribe_to "publish_batch.publisher.sidekiq_publisher"
+      subscribe_to "enqueue_batch.publisher.sidekiq_publisher"
+    end
+
+    class JobSubscriber < Subscriber
+      def start(_name, _id, payload)
+        start_span("job.purge", payload)
+      end
+
+      def finish(_name, _id, payload)
+        payload[:datadog_span]&.set_tag(:purged_count, payload[:purged_count]) if payload.key?(:purged_count)
+
+        super
+      end
+
+      subscribe_to "purge.job.sidekiq_publisher"
+    end
+
+    # This subscriber is different from the classes above because it is an ActiveSupport::Subscriber
+    # and responds to the error(.publisher.sidekiq_publisher) event.
+    class PublisherErrorSubscriber < ActiveSupport::Subscriber
+      def error(event)
+        Datadog.tracer.active_span&.set_error(event.payload[:exception_object])
+      end
+
+      attach_to "publisher.sidekiq_publisher"
+    end
+  end
+end

--- a/lib/sidekiq_publisher/exception_reporter.rb
+++ b/lib/sidekiq_publisher/exception_reporter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "active_support/subscriber"
+
+module SidekiqPublisher
+  module ExceptionReporter
+    class PublisherErrorSubscriber < ActiveSupport::Subscriber
+      def error(event)
+        SidekiqPublisher.exception_reporter&.call(event.payload[:exception_object])
+      end
+
+      attach_to "publisher.sidekiq_publisher"
+    end
+  end
+end

--- a/lib/sidekiq_publisher/instrumenter.rb
+++ b/lib/sidekiq_publisher/instrumenter.rb
@@ -1,25 +1,13 @@
 # frozen_string_literal: true
 
+require "active_support/notifications"
+
 module SidekiqPublisher
   class Instrumenter
     NAMESPACE = "sidekiq_publisher"
 
-    def initialize
-      @backend = if defined?(ActiveSupport::Notifications)
-                   ActiveSupport::Notifications
-                 end
-    end
-
     def instrument(event_name, payload = {}, &block)
-      if backend
-        backend.instrument("#{event_name}.#{NAMESPACE}", payload, &block)
-      elsif block
-        yield(payload)
-      end
+      ActiveSupport::Notifications.instrument("#{event_name}.#{NAMESPACE}", payload, &block)
     end
-
-    private
-
-    attr_reader :backend
   end
 end

--- a/lib/sidekiq_publisher/job.rb
+++ b/lib/sidekiq_publisher/job.rb
@@ -45,7 +45,6 @@ module SidekiqPublisher
         notification[:purged_count] = purgeable.delete_all
       end
       SidekiqPublisher.logger.info("#{name} purged #{count} expired published jobs.")
-      SidekiqPublisher.metrics_reporter.try(:count, "sidekiq_publisher.purged", count)
     end
 
     def self.unpublished_batches(batch_size: SidekiqPublisher.batch_size)

--- a/lib/sidekiq_publisher/metrics_reporter.rb
+++ b/lib/sidekiq_publisher/metrics_reporter.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "active_support/subscriber"
+
+module SidekiqPublisher
+  module MetricsReporter
+    class Subscriber < ActiveSupport::Subscriber
+      private
+
+      def count(metric, value)
+        SidekiqPublisher.metrics_reporter&.try(:count, metric, value) unless value.nil?
+      end
+    end
+
+    class PublisherSubscriber < Subscriber
+      def enqueue_batch(event)
+        count("sidekiq_publisher.published", event.payload[:published_count])
+      end
+
+      attach_to "publisher.sidekiq_publisher"
+    end
+
+    class JobSubscriber < Subscriber
+      def purge(event)
+        count("sidekiq_publisher.purged", event.payload[:purged_count])
+      end
+
+      attach_to "job.sidekiq_publisher"
+    end
+
+    class UnpublishedSubscriber < Subscriber
+      def unpublished(event)
+        SidekiqPublisher.metrics_reporter&.
+          try(:gauge, "sidekiq_publisher.unpublished_count", event.payload[:unpublished_count])
+      end
+
+      attach_to "reporter.sidekiq_publisher"
+    end
+  end
+end

--- a/lib/sidekiq_publisher/publisher.rb
+++ b/lib/sidekiq_publisher/publisher.rb
@@ -48,7 +48,6 @@ module SidekiqPublisher
     ensure
       published_count = update_jobs_as_published!(batch) if pushed_count.present? && published_count.nil?
       notification[:published_count] = published_count if published_count.present?
-      metrics_reporter.try(:count, "sidekiq_publisher.published", published_count) if published_count.present?
     end
 
     def lookup_job_class(name)
@@ -71,17 +70,12 @@ module SidekiqPublisher
 
     def failure_warning(method, ex)
       logger.warn("#{self.class.name}: msg=\"#{method} failed\" error=#{ex.class} error_msg=#{ex.message.inspect}\n")
-      SidekiqPublisher.exception_reporter&.call(ex)
       instrumenter.instrument("error.publisher",
                               exception_object: ex, exception: [ex.class.name, ex.message])
     end
 
     def logger
       SidekiqPublisher.logger
-    end
-
-    def metrics_reporter
-      SidekiqPublisher.metrics_reporter
     end
   end
 end

--- a/lib/sidekiq_publisher/report_unpublished_count.rb
+++ b/lib/sidekiq_publisher/report_unpublished_count.rb
@@ -2,10 +2,9 @@
 
 module SidekiqPublisher
   module ReportUnpublishedCount
-    def self.call
-      SidekiqPublisher.metrics_reporter.
-        gauge("sidekiq_publisher.unpublished_count",
-              SidekiqPublisher::Job.unpublished.count)
+    def self.call(instrumenter: Instrumenter.new)
+      instrumenter.instrument("unpublished.reporter",
+                              unpublished_count: SidekiqPublisher::Job.unpublished.count)
     end
   end
 end

--- a/lib/sidekiq_publisher/version.rb
+++ b/lib/sidekiq_publisher/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqPublisher
-  VERSION = "1.7.0"
+  VERSION = "1.7.0.rc1"
 end

--- a/sidekiq_publisher.gemspec
+++ b/sidekiq_publisher.gemspec
@@ -45,6 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "database_cleaner"
+  spec.add_development_dependency "ddtrace", ">= 0.39.0"
   spec.add_development_dependency "ezcater_matchers"
   spec.add_development_dependency "ezcater_rubocop", "1.0.2"
   spec.add_development_dependency "factory_bot"

--- a/spec/sidekiq_publisher/datadog_apm_spec.rb
+++ b/spec/sidekiq_publisher/datadog_apm_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+RSpec.describe SidekiqPublisher::DatadogAPM do
+  let(:instrumenter) { SidekiqPublisher::Instrumenter.new }
+  let(:service) { "sidekiq-publisher" }
+  let(:trace) { Datadog.tracer.traces.first }
+  let(:span) { trace.first }
+
+  describe ".service" do
+    context "when unset" do
+      it "returns sidekiq-publisher" do
+        expect(described_class.service).to eq("sidekiq-publisher")
+      end
+    end
+
+    context "when set" do
+      let(:service) { "test-sidekiq-publisher" }
+
+      before { described_class.service = service }
+
+      after { described_class.service = nil }
+
+      it "returns the configured service" do
+        expect(described_class.service).to eq(service)
+      end
+    end
+  end
+
+  shared_examples_for "trace error handling" do |event_name|
+    let!(:error) { RuntimeError.new(SecureRandom.uuid) }
+
+    it "adds any error to the #{event_name} span" do
+      begin
+        instrumenter.instrument(event_name) do
+          raise error
+        end
+      rescue StandardError
+        nil
+      end
+
+      expect(span).to have_error(error)
+    end
+  end
+
+  describe "ListenerSubscriber" do
+    it "creates a span for a listener.timeout resource" do
+      instrumenter.instrument("timeout.listener") {}
+      expect(span.service).to eq(service)
+      expect(span.name).to eq("sidekiq_publisher")
+      expect(span.resource).to eq("listener.timeout")
+    end
+
+    it_behaves_like "trace error handling", "timeout.listener"
+  end
+
+  describe "RunnerSubscriber" do
+    it "creates a span for a publisher.start resource" do
+      instrumenter.instrument("start.publisher") {}
+      expect(span.service).to eq(service)
+      expect(span.name).to eq("sidekiq_publisher")
+      expect(span.resource).to eq("publisher.start")
+    end
+
+    it "creates a span for a publisher.notify resource" do
+      instrumenter.instrument("notify.publisher") {}
+      expect(span.service).to eq(service)
+      expect(span.name).to eq("sidekiq_publisher")
+      expect(span.resource).to eq("publisher.notify")
+    end
+
+    it "creates a span for a publisher.timeout resource" do
+      instrumenter.instrument("timeout.publisher") {}
+      expect(span.service).to eq(service)
+      expect(span.name).to eq("sidekiq_publisher")
+      expect(span.resource).to eq("publisher.timeout")
+    end
+
+    it_behaves_like "trace error handling", "start.publisher"
+    it_behaves_like "trace error handling", "notify.publisher"
+    it_behaves_like "trace error handling", "timeout.publisher"
+  end
+
+  describe "PublisherSubscriber" do
+    it "creates a span for a publisher.publish_batch operation" do
+      instrumenter.instrument("publish_batch.publisher") {}
+      expect(span.service).to eq(service)
+      expect(span.name).to eq("publisher.publish_batch")
+    end
+
+    it "creates a span for a publisher.enqueue_batch operation" do
+      published_count = rand(1..100)
+      instrumenter.instrument("publish_batch.publisher") do
+        instrumenter.instrument("enqueue_batch.publisher") do |notification|
+          notification[:published_count] = published_count
+        end
+      end
+      span = trace.last
+      expect(span).to have_tag(:published_count).with_value(published_count)
+      expect(span.service).to eq(service)
+      expect(span.name).to eq("publisher.enqueue_batch")
+    end
+
+    it_behaves_like "trace error handling", "publish_batch.publisher"
+    it_behaves_like "trace error handling", "enqueue_batch.publisher"
+  end
+
+  describe "PublisherErrorSubscriber" do
+    let(:error) { RuntimeError.new("boom") }
+    let(:payload) { { exception_object: error, exception: [error.class.name, error.message] } }
+
+    it "adds an error to the current span" do
+      Datadog.tracer.trace("example") do
+        instrumenter.instrument("error.publisher", payload)
+      end
+
+      expect(span).to have_error(error)
+    end
+  end
+
+  describe "JobSubscriber" do
+    it "creates a span for a job.purge operation" do
+      purged_count = rand(1..100)
+      instrumenter.instrument("purge.job") do |notification|
+        notification[:purged_count] = purged_count
+      end
+
+      expect(span).to have_tag(:purged_count).with_value(purged_count)
+      expect(span.service).to eq(service)
+      expect(span.name).to eq("job.purge")
+    end
+
+    it_behaves_like "trace error handling", "purge.job"
+  end
+
+  matcher :have_tag do |name|
+    match do |span|
+      tag = span.get_tag(name)
+      values_match?(value, tag)
+    end
+
+    chain :with_value, :value
+
+    failure_message do
+      "expected span to have tag #{expected} with value #{value}"
+    end
+  end
+
+  matcher :have_error do |expected|
+    attr_accessor :error_type, :error_msg
+
+    match do |span|
+      self.error_type = span.get_tag("error.type")
+      self.error_msg = span.get_tag("error.msg")
+      values_match?(expected.class.name, error_type) && values_match?(expected.message, error_msg)
+    end
+
+    failure_message do
+      "expected span to have error #{expected.inspect} got #<#{error_type}: #{error_msg}>"
+    end
+  end
+end

--- a/spec/sidekiq_publisher/exception_reporter_spec.rb
+++ b/spec/sidekiq_publisher/exception_reporter_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe SidekiqPublisher::ExceptionReporter do
+  describe "PublisherErrorSubscriber" do
+    let(:instance) { described_class::PublisherErrorSubscriber.new }
+    let(:event) { instance_double(ActiveSupport::Notifications::Event, payload: payload) }
+    let(:error) { RuntimeError.new("boom") }
+    let(:payload) do
+      { exception_object: error, exception: [error.class.name, error.message] }
+    end
+
+    describe "#error" do
+      context "when an exception reporter is configured" do
+        let(:exception_reporter) { instance_double(Proc) }
+
+        before do
+          allow(exception_reporter).to receive(:call)
+          SidekiqPublisher.exception_reporter = exception_reporter
+        end
+
+        it "reports the error to the exception reporter" do
+          instance.error(event)
+
+          expect(SidekiqPublisher.exception_reporter).to have_received(:call).with(error)
+        end
+      end
+
+      context "without an exception reporter" do
+        it "does not raise an error" do
+          expect do
+            instance.error(event)
+          end.not_to raise_error
+        end
+      end
+    end
+  end
+end

--- a/spec/sidekiq_publisher/instrumenter_spec.rb
+++ b/spec/sidekiq_publisher/instrumenter_spec.rb
@@ -4,36 +4,16 @@ RSpec.describe SidekiqPublisher::Instrumenter, skip_db_clean: true do
   let(:instrumenter) { described_class.new }
   let(:payload) { Hash.new[a: 1] }
 
-  context "when ActiveSupport::Notifications is defined" do
-    describe "#instrument" do
-      before do
-        allow(ActiveSupport::Notifications).to receive(:instrument).and_call_original
-      end
-
-      it "calls instrument on ActiveSupport::Notifications" do
-        instrumenter.instrument("foo", payload)
-
-        expect(ActiveSupport::Notifications).to have_received(:instrument).
-          with("foo.sidekiq_publisher", payload)
-      end
-
-      context "with a block" do
-        it "calls the block with the payload" do
-          expect do |blk|
-            instrumenter.instrument("foo", payload, &blk)
-          end.to yield_with_args(payload)
-        end
-      end
-    end
-  end
-
-  context "when ActiveSupport::Notifications is not defined" do
+  describe "#instrument" do
     before do
-      hide_const("ActiveSupport::Notifications")
+      allow(ActiveSupport::Notifications).to receive(:instrument).and_call_original
     end
 
-    it "is a no-op" do
+    it "calls instrument on ActiveSupport::Notifications" do
       instrumenter.instrument("foo", payload)
+
+      expect(ActiveSupport::Notifications).to have_received(:instrument).
+        with("foo.sidekiq_publisher", payload)
     end
 
     context "with a block" do

--- a/spec/sidekiq_publisher/job_spec.rb
+++ b/spec/sidekiq_publisher/job_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe SidekiqPublisher::Job, type: :model do
       expect(payload[:purged_count]).to eq(1)
     end
 
-    context "with a metrics_reporter configured" do
+    context "with a metrics_reporter configured", :integration do
       include_context "metrics_reporter context"
 
       it "records a metric for the number of jobs purged" do

--- a/spec/sidekiq_publisher/metrics_reporter_spec.rb
+++ b/spec/sidekiq_publisher/metrics_reporter_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+RSpec.describe SidekiqPublisher::MetricsReporter do
+  let(:event) { instance_double(ActiveSupport::Notifications::Event, payload: payload) }
+
+  describe "PublisherSubscriber" do
+    describe "#enqueue_batch" do
+      let(:instance) { described_class::PublisherSubscriber.new }
+      let(:payload) { { published_count: rand(1..100) } }
+
+      context "when a metrics_reporter is configured" do
+        include_context "metrics_reporter context"
+
+        it "reports a count of the jobs published" do
+          instance.enqueue_batch(event)
+
+          expect(metrics_reporter).to have_received(:try).
+            with(:count, "sidekiq_publisher.published", payload[:published_count])
+        end
+      end
+
+      context "when there is no metrics_reporter configured" do
+        it "does not raise an error" do
+          expect do
+            instance.enqueue_batch(event)
+          end.not_to raise_error
+        end
+      end
+    end
+  end
+
+  describe "JobSubscriber" do
+    describe "#purge" do
+      let(:instance) { described_class::JobSubscriber.new }
+      let(:payload) { { purged_count: rand(1..100) } }
+
+      context "when a metrics_reporter is configured" do
+        include_context "metrics_reporter context"
+
+        it "reports a count of the jobs purged" do
+          instance.purge(event)
+
+          expect(metrics_reporter).to have_received(:try).
+            with(:count, "sidekiq_publisher.purged", payload[:purged_count])
+        end
+      end
+
+      context "when there is no metrics_reporter configured" do
+        it "does not raise an error" do
+          expect do
+            instance.purge(event)
+          end.not_to raise_error
+        end
+      end
+    end
+  end
+
+  describe "UnpublishedSubscriber" do
+    describe "#unpublished" do
+      let(:instance) { described_class::UnpublishedSubscriber.new }
+      let(:payload) { { unpublished_count: rand(1..100) } }
+
+      context "when a metrics_reporter is configured" do
+        include_context "metrics_reporter context"
+
+        it "reports a count of the jobs purged" do
+          instance.unpublished(event)
+
+          expect(metrics_reporter).to have_received(:try).
+            with(:gauge, "sidekiq_publisher.unpublished_count", payload[:unpublished_count])
+        end
+      end
+
+      context "when there is no metrics_reporter configured" do
+        it "does not raise an error" do
+          expect do
+            instance.unpublished(event)
+          end.not_to raise_error
+        end
+      end
+    end
+  end
+end

--- a/spec/support/datadog/test_tracer.rb
+++ b/spec/support/datadog/test_tracer.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "ddtrace/tracer"
+
+module Datadog
+  class TestTracer < Tracer
+    attr_reader :traces
+
+    def initialize
+      @traces = Array.new
+      super(enabled: true)
+      configure(transport_options: proc { |t| t.adapter :test })
+    end
+
+    def reset!
+      @traces.clear
+    end
+
+    def write(trace)
+      @traces << trace
+      super
+    end
+  end
+end


### PR DESCRIPTION
## What did we change?

- Reimplemented `metrics_reporter` and `exception_reporter` support using subscribers.
- Added example of Datadog APM integration.

## Why are we doing this?

Implementation using subscribers provides more flexibility.

We will use the Datadog APM integration but this is intentionally optional here. We will use another, internal library to require to this integration.

This PR got a little bigger than expected. It is broken up to cover Datadog APM integration and the existing instrumentation refactor, so it is probably more manageable to review by commit.

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
