### PR TITLE
Attempt to reconnect when encountering certain PG errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # sidekiq_publisher
 
+## v1.7.1 (unreleased)
+- Gracefully handle database connection errors by attempting to reconnect
+
 ## v1.7.0
 - Add instrumentation using `ActiveSupport::Notifications`.
 - Reimplement `metrics_reporter` and `exception_reporter` support using

--- a/lib/sidekiq_publisher/report_unpublished_count.rb
+++ b/lib/sidekiq_publisher/report_unpublished_count.rb
@@ -1,10 +1,17 @@
 # frozen_string_literal: true
 
+require "active_record"
+require "pg"
+
 module SidekiqPublisher
   module ReportUnpublishedCount
     def self.call(instrumenter: Instrumenter.new)
       instrumenter.instrument("unpublished.reporter",
                               unpublished_count: SidekiqPublisher::Job.unpublished.count)
+    rescue ActiveRecord::StatementInvalid, PG::UnableToSend, PG::ConnectionBad => e
+      cause = e.is_a?(ActiveRecord::StatementInvalid) ? e.cause : e
+      ActiveRecord::Base.clear_active_connections! if cause.is_a?(PG::UnableToSend) || cause.is_a?(PG::ConnectionBad)
+      raise
     end
   end
 end

--- a/lib/sidekiq_publisher/report_unpublished_count.rb
+++ b/lib/sidekiq_publisher/report_unpublished_count.rb
@@ -9,9 +9,14 @@ module SidekiqPublisher
       instrumenter.instrument("unpublished.reporter",
                               unpublished_count: SidekiqPublisher::Job.unpublished.count)
     rescue ActiveRecord::StatementInvalid, PG::UnableToSend, PG::ConnectionBad => e
-      cause = e.is_a?(ActiveRecord::StatementInvalid) ? e.cause : e
-      ActiveRecord::Base.clear_active_connections! if cause.is_a?(PG::UnableToSend) || cause.is_a?(PG::ConnectionBad)
+      ActiveRecord::Base.clear_active_connections! if db_connection_error?(e)
       raise
     end
+
+    def self.db_connection_error?(error)
+      cause = error.is_a?(ActiveRecord::StatementInvalid) ? error.cause : error
+      cause.is_a?(PG::UnableToSend) || cause.is_a?(PG::ConnectionBad)
+    end
+    private_class_method :db_connection_error?
   end
 end


### PR DESCRIPTION
## What did we change?
Reconnnect DB connection with [`.clear_active_connections!`](https://github.com/rails/rails/blob/9492339979e94570dee00d071be0ef255065837a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L1061-L1066) when encountering certain PG errors

## Why are we doing this?
The `SidekiqPublisher::ReportUnpublishedCount` will often run in a long running process meant to capture current stats for `SidekiqPublisher`.

If a connection error occurs (like during a db failover), the gem will not gracefully handle it. The database connection gets "poisoned" and all subsequent calls will continue to use this connection and fail. It will continue to do so until the process gets restarted or if you a new connection is fetched.

Fixes https://github.com/ezcater/sidekiq_publisher/issues/41

## How was it tested?
- [x] Specs
- [x] Locally
- [ ] Staging
