### PR TITLE
Add Readme section about exception reporting with ActiveJob

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,21 @@ class MyJob < ApplicationJob
 end
 ```
 
+#### ActiveJob Exception Reporting
+
+Many exception monitoring service (e.g. Sentry, Airbrake, Honeybadger, etc) already provide basic integration support for `Sidekiq`. 
+These integration should also work with `SidekiqPublisher`. 
+However, you may need to explicitly include 
+`ActiveJob::QueueAdapters::SidekiqPublisherAdapter` as a compatible adapter for this to work properly.
+
+Alternatively, you can manually report the exception:
+
+ ```ruby
+retry_on SomeError, attempts: 10 do |_job, exception|
+  Raven.capture_exception(exception, extra: { custom: :foo }) # Reporting using the Sentry gem 
+end
+```
+
 ### SidekiqPublisher::Worker
 
 Sidekiq workers are usually defined by including `Sidekiq::Worker` in a class.


### PR DESCRIPTION
## What did we change?
- Add Readme section about exception reporting with ActiveJob

## Why are we doing this?
- Not all exception reporting gems support `SidekiqPublisherAdapter` out of the box. So calling out alternatives for reporting them
  - For example, these are the [adapters Sentry supports by default](https://github.com/getsentry/sentry-ruby/blob/44f347ee2a8c55b3830e47b453ceb663e28990b4/sentry-rails/lib/sentry/rails/active_job.rb#L4-L7)

## How was it tested?
- [ ] Specs
- [ ] Locally
- [ ] Staging
