### PR TITLE
Transition from defining a Railtie to becoming a Rails Engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # sidekiq_publisher
 
+## Unreleased
+- Transition from defining a Railtie to becoming a Rails Engine.
+
 ## v1.8.0
 - Extend support to Rails 6.1.
 

--- a/app/models/sidekiq_publisher/job.rb
+++ b/app/models/sidekiq_publisher/job.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_record"
-
 module SidekiqPublisher
   class Job < ActiveRecord::Base
     self.table_name = "sidekiq_publisher_jobs"

--- a/lib/active_job/queue_adapters/sidekiq_publisher_adapter.rb
+++ b/lib/active_job/queue_adapters/sidekiq_publisher_adapter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_job/queue_adapters/sidekiq_adapter"
+require "active_support/core_ext/object/blank"
 
 module ActiveJob
   module QueueAdapters

--- a/lib/sidekiq_publisher.rb
+++ b/lib/sidekiq_publisher.rb
@@ -7,11 +7,10 @@ require "sidekiq_publisher/instrumenter"
 require "sidekiq_publisher/metrics_reporter"
 require "sidekiq_publisher/exception_reporter"
 require "sidekiq_publisher/report_unpublished_count"
-require "sidekiq_publisher/job"
 require "sidekiq_publisher/worker"
 require "sidekiq_publisher/publisher"
 require "sidekiq_publisher/runner"
-require "sidekiq_publisher/railtie" if defined?(Rails)
+require "sidekiq_publisher/engine" if defined?(Rails)
 
 module SidekiqPublisher
   DEFAULT_BATCH_SIZE = 100

--- a/lib/sidekiq_publisher.rb
+++ b/lib/sidekiq_publisher.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support"
+require "active_support/core_ext/numeric/time"
 require "sidekiq_publisher/version"
 require "sidekiq_publisher/instrumenter"
 require "sidekiq_publisher/metrics_reporter"

--- a/lib/sidekiq_publisher/engine.rb
+++ b/lib/sidekiq_publisher/engine.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 module SidekiqPublisher
-  class Railtie < Rails::Railtie
-    rake_tasks do
-      load "sidekiq_publisher/tasks.rake"
-    end
+  class Engine < Rails::Engine
+    isolate_namespace SidekiqPublisher
 
     initializer "sidekiq_publisher.configure" do
       SidekiqPublisher.logger = Rails.logger

--- a/lib/sidekiq_publisher/metrics_reporter.rb
+++ b/lib/sidekiq_publisher/metrics_reporter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/subscriber"
+require "active_support/core_ext/object/try"
 
 module SidekiqPublisher
   module MetricsReporter

--- a/lib/sidekiq_publisher/publisher.rb
+++ b/lib/sidekiq_publisher/publisher.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "sidekiq_publisher/client"
-require "active_support/core_ext/object/try"
+require "active_support/core_ext/object/blank"
 
 module SidekiqPublisher
   class Publisher

--- a/lib/tasks/sidekiq_publisher.rake
+++ b/lib/tasks/sidekiq_publisher.rake
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 namespace :sidekiq_publisher do
+  desc "Start the Sidekiq Publisher runner"
   task publish: [:environment] do
     Signal.trap("INT") { exit(0) }
     Signal.trap("TERM") { exit(0) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+$LOAD_PATH.unshift File.expand_path("../app/models", __dir__)
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "simplecov"
 SimpleCov.start
+
+require "active_record"
+require "sidekiq_publisher/job"
 
 require "active_support/notifications"
 require "sidekiq_publisher/datadog_apm"


### PR DESCRIPTION
Hi folks!!

## What did we change?

The gem is now integrating with Rails via `Rails::Engine` rather than `Rails::Railtie`, leveraging the autoloading of `app/models`.

## Why are we doing this?

When going through the process of upgrading an application that uses sidekiq_publisher to Ruby 3, we ran into a really weird situation that somehow was traced to the `SidekiqPublisher::Job` AR model.

Essentially, when booting the application, with the `SidekiqPublisher::Job` class included, the application fails to boot, hanging indefinitely in some kind of endless loop inside of native Ruby C code. Tracing things via `lldb` did not provide much more information into what the root cause is, so I went through the process of simply commenting out various gems (starting first with those that have C extensions), eventually removing sidekiq_publisher, when things all of a sudden started working. I then proceeded to do a similar thing with various parts of this gem, before temporarily removing `SidekiqPublisher::Job`, and having that turn out to be the culprit.

What is truly infuriating is that when attempting to do this on a fresh Rails 6.0.3.4 application (the version our application is currently on), this behavior does not occur, which I'd imagine means there is some interplay issues going on with some other gem/code.

I wish I had more specific details about why that class is an issue, but I have yet to reduce the issue down to a minimal reproducible case. What I *was* able to figure out is that removing the explicit `require 'activerecord'` and transitioning this gem to a Rails Engine resolves things, I believe due to the way Rails handles the order of loading models included in an engine.

I'd love to learn more about why this *actually* resolves the issues we've run into, but on the bright side, the resolution was pretty simple, and actually simplifies the `SidekiqPublisher::Job` class by not needing to `require 'activerecord'` explicitly, nor `require 'sidekiq_publisher/job'` itself.

## How was it tested?
- [x] Specs
- [x] Locally
- [x] Staging
