### PR TITLE
Add support for sidekiq `7.0.0`

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -36,6 +36,12 @@ appraise "rails-5.2-sidekiq-6.2" do
   gem "sidekiq", "~> 6.2.0"
 end
 
+appraise "rails-5.2-sidekiq-6.3" do
+  gem "activejob", "~> 5.2.0"
+  gem "activesupport", "~> 5.2.0"
+  gem "sidekiq", "~> 6.3.0"
+end
+
 appraise "rails-6.0-sidekiq-5.2" do
   gem "activejob", "~> 6.0.0"
   gem "activesupport", "~> 6.0.0"
@@ -60,6 +66,12 @@ appraise "rails-6.0-sidekiq-6.2" do
   gem "sidekiq", "~> 6.2.0"
 end
 
+appraise "rails-6.0-sidekiq-6.3" do
+  gem "activejob", "~> 6.0.0"
+  gem "activesupport", "~> 6.0.0"
+  gem "sidekiq", "~> 6.3.0"
+end
+
 appraise "rails-6.1-sidekiq-5.2" do
   gem "activejob", "~> 6.1.0"
   gem "activesupport", "~> 6.1.0"
@@ -82,4 +94,10 @@ appraise "rails-6.1-sidekiq-6.2" do
   gem "activejob", "~> 6.1.0"
   gem "activesupport", "~> 6.1.0"
   gem "sidekiq", "~> 6.2.0"
+end
+
+appraise "rails-6.1-sidekiq-6.3" do
+  gem "activejob", "~> 6.1.0"
+  gem "activesupport", "~> 6.1.0"
+  gem "sidekiq", "~> 6.3.0"
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # sidekiq_publisher
 
+## (Unreleased)
+- Add support for sidekiq `7.0.0` by using `Sidekiq::Job` instead of
+  `Sidekiq::Worker` in sidekiq `>= 6.3.0` to handle name changes outlined in
+  mperham/sidekiq#4971 and first introduced in 6.2.2.
+
 ## 2.0.1
 - Changing the `Job#args` validator to be a manual check instead of using the `exclusions` validator.  This is to fix an issue introduced with rails 6.1 and the condition of `in: [nil]`.  More details [here](https://github.com/rails/rails/issues/41051).
 

--- a/README.md
+++ b/README.md
@@ -138,22 +138,23 @@ end
 
 #### ActiveJob Exception Reporting
 
-Many exception monitoring service (e.g. Sentry, Airbrake, Honeybadger, etc) already provide basic integration support for `Sidekiq`. 
-These integration should also work with `SidekiqPublisher`. 
-However, you may need to explicitly include 
+Many exception monitoring service (e.g. Sentry, Airbrake, Honeybadger, etc) already provide basic integration support for `Sidekiq`.
+These integration should also work with `SidekiqPublisher`.
+However, you may need to explicitly include
 `ActiveJob::QueueAdapters::SidekiqPublisherAdapter` as a compatible adapter for this to work properly.
 
 Alternatively, you can manually report the exception:
 
  ```ruby
 retry_on SomeError, attempts: 10 do |_job, exception|
-  Raven.capture_exception(exception, extra: { custom: :foo }) # Reporting using the Sentry gem 
+  Raven.capture_exception(exception, extra: { custom: :foo }) # Reporting using the Sentry gem
 end
 ```
 
 ### SidekiqPublisher::Worker
 
-Sidekiq workers are usually defined by including `Sidekiq::Worker` in a class.
+Sidekiq workers are usually defined by including `Sidekiq::Job` or
+`Sidekiq::Worker` in a class.
 
 To use the `SidekiqPublisher`, this can be replaced by including
 `SidekiqPublisher::Worker`. The usual `perform_async`, etc methods will be

--- a/lib/sidekiq_publisher.rb
+++ b/lib/sidekiq_publisher.rb
@@ -3,6 +3,7 @@
 require "active_support"
 require "active_support/core_ext/numeric/time"
 require "sidekiq_publisher/version"
+require "sidekiq_publisher/compatibility"
 require "sidekiq_publisher/instrumenter"
 require "sidekiq_publisher/metrics_reporter"
 require "sidekiq_publisher/exception_reporter"

--- a/lib/sidekiq_publisher/compatibility.rb
+++ b/lib/sidekiq_publisher/compatibility.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module SidekiqPublisher
+  module Compatibility
+    class << self
+      # Sidekiq::Worker will be renamed to Sidekiq::Job in sidekiq 7.0.0 and a
+      # deprecation warning will be printed in sidekiq 6.4.0, per
+      # mperham/sidekiq#4971. Sidekiq 6.2.2 (mperham/sidekiq@8e36432) introduces
+      # an alias and 6.3.0 includes it when the gem is loaded. This alias is
+      # used here to ensure future compatibility.
+      def sidekiq_job_class
+        @_sidekiq_job_class ||= Gem::Dependency.new("sidekiq", ">= 6.3.0").then do |dependency|
+          if dependency.match?(Gem.loaded_specs["sidekiq"])
+            Sidekiq::Job
+          else
+            Sidekiq::Worker
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/sidekiq_publisher/worker.rb
+++ b/lib/sidekiq_publisher/worker.rb
@@ -3,7 +3,7 @@
 module SidekiqPublisher
   module Worker
     def self.included(base)
-      base.include(Sidekiq::Worker)
+      base.include(SidekiqPublisher::Compatibility.sidekiq_job_class)
       base.singleton_class.public_send(:alias_method, :sidekiq_client_push, :client_push)
       base.extend(ClassMethods)
     end


### PR DESCRIPTION
## What did we change?

Use `Sidekiq::Job` over `Sidekiq::Worker` in versions of sidekiq in which it has been renamed.

## Why are we doing this?

Resolves #49 

This adds support for sidekiq `7.0.0` which will rename `Sidekiq::Worker` to `Sidekiq::Job` per mperham/sidekiq#4971:
- In sidekiq `6.4.0`, deprectation warnings will start being printed when `Sidekiq::Worker` is used.
- In sidekiq `7.0.0`, `Sidekiq::Worker` will be permanently renamed to `Sidekiq::Job`.

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
