### PR TITLE
Opt-in to Rubygems MFA for privileged operations. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # sidekiq_publisher
 
+## (Unreleased)
+- Opt-in to [Rubygems MFA](https://guides.rubygems.org/mfa-requirement-opt-in/)
+  for privileged operations
+
 ## 2.1.0
 - Add support for sidekiq `7.0.0` by using `Sidekiq::Job` instead of
   `Sidekiq::Worker` in sidekiq `>= 6.3.0` to handle name changes outlined in

--- a/sidekiq_publisher.gemspec
+++ b/sidekiq_publisher.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   # Set "allowed_push_post" to control where this gem can be published.
   if spec.respond_to?(:metadata)
     spec.metadata["allowed_push_host"] = "https://rubygems.org"
-
+    spec.metadata["rubygems_mfa_required"] = "true"
   else
     raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end


### PR DESCRIPTION
## What did we change?

Opt-in to Rubygems MFA for privileged operations.

## Why are we doing this?

Resolves #52 by opting in to [Rubygems MFA](https://guides.rubygems.org/mfa-requirement-opt-in/) for privileged operations. This ensures that future push, yank, and ownership change operations require the actor to authenticate with MFA, reducing risk in the scenario where a rubygems owner's account password is compromised.

## How was it tested?
- [ ] Specs
- [ ] Locally
- [ ] Staging
