### PR TITLE
Add support for redis 5.0.0 by replacing pipelined commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # sidekiq_publisher
 
+## Unreleased
+- Add support for redis 5.0.0 by replacing pipelined commands.
+  - Also resolves deprecation warnings introduced in [redis 4.6.0]
+
+[redis 4.6.0]: https://github.com/redis/redis-rb/blob/master/CHANGELOG.md#460
+
 ## 2.1.1
 - Opt-in to [Rubygems MFA](https://guides.rubygems.org/mfa-requirement-opt-in/)
   for privileged operations

--- a/lib/sidekiq_publisher/client.rb
+++ b/lib/sidekiq_publisher/client.rb
@@ -12,9 +12,9 @@ module SidekiqPublisher
 
       pushed = 0
       with_connection do |conn|
-        conn.multi do
+        conn.multi do |transaction|
           payloads.each do |payload|
-            atomic_push(conn, [payload])
+            atomic_push(transaction, [payload])
             pushed += 1
           end
         end


### PR DESCRIPTION
## What did we change?

This change alters the `bulk_push` implementation so that it no longer uses pipelined commands, which are now deprecated.

## Why are we doing this?

Resolves #54

Deprecation warnings for pipelined commands were introduced in [redis 4.6.0](https://github.com/redis/redis-rb/blob/master/CHANGELOG.md#460)

These warnings contribute to a large increase in log volume with newer versions of the redis gem.

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
