### PR TITLE
restrict sidekiq to < 6.4.2 due to an incompatability issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # sidekiq_publisher
 
-## Unreleased
+## 2.2.0
 - Add support for redis 5.0.0 by replacing pipelined commands.
   - Also resolves deprecation warnings introduced in [redis 4.6.0]
 
 [redis 4.6.0]: https://github.com/redis/redis-rb/blob/master/CHANGELOG.md#460
+
+- Restricts sidekiq to < 6.4.2 due to an incompatability
+  - [issue tracking this](https://github.com/ezcater/sidekiq_publisher/issues/55)
 
 ## 2.1.1
 - Opt-in to [Rubygems MFA](https://guides.rubygems.org/mfa-requirement-opt-in/)

--- a/lib/sidekiq_publisher/version.rb
+++ b/lib/sidekiq_publisher/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqPublisher
-  VERSION = "2.1.1"
+  VERSION = "2.2.0"
 end

--- a/sidekiq_publisher.gemspec
+++ b/sidekiq_publisher.gemspec
@@ -61,5 +61,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "activerecord-postgres_pub_sub", ">= 0.4.0"
   spec.add_runtime_dependency "activesupport", ">= 5.1", "< 6.2"
-  spec.add_runtime_dependency "sidekiq", ">= 5.0.4", "< 7.0"
+  spec.add_runtime_dependency "sidekiq", ">= 5.0.4", "< 6.4.2"
 end


### PR DESCRIPTION
## What did we change?
restrict sidekiq to < 6.4.2

## Why are we doing this?
there is [an incompatability](https://github.com/ezcater/sidekiq_publisher/issues/55) between this gem and sidekiq  >= 6.4.2

## How was it tested?
- [ ] Specs
- [ ] Locally
- [ ] Staging
