### PR TITLE
Update active-support dependency to include any 7.x.x version

### DIFF
--- a/sidekiq_publisher.gemspec
+++ b/sidekiq_publisher.gemspec
@@ -60,6 +60,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", "< 0.18"
 
   spec.add_runtime_dependency "activerecord-postgres_pub_sub", ">= 0.4.0"
-  spec.add_runtime_dependency "activesupport", ">= 5.1", "< 6.2"
+  spec.add_runtime_dependency "activesupport", ">= 5.1", "< 7.1"
   spec.add_runtime_dependency "sidekiq", ">= 5.0.4", "< 7"
 end


### PR DESCRIPTION
## What did we change?
Update active-support dependency to include any 7.x.x version

## Why are we doing this?
Enables the gem to be used with repos using Rails 7.x

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
