### PR TITLE
Update package to version 2.4.0 to include the activesupport dependancy changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## (Unreleased)
 
+## 2.4.0
+- Update active_support dependency to allow any active_support 7.x.x version
+
 ## 2.3.0
 - Add support for ddtrace 1.x.
 - Add support for sidekiq 6.4.2+.

--- a/lib/sidekiq_publisher/version.rb
+++ b/lib/sidekiq_publisher/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqPublisher
-  VERSION = "2.3.0"
+  VERSION = "2.4.0"
 end


### PR DESCRIPTION
## What did we change?
  Adds activesupport support for up to but not including version 7.1.0
## Why are we doing this?

## How was it tested?
- [ ] Specs
- [ ] Locally
- [ ] Staging
