### PR TITLE
Remove the Code Climate configuration.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,12 +24,6 @@ jobs:
             - ruby-cache-{{ arch }}-{{ .Branch }}-
             - ruby-cache-
 
-      - run:
-          name: Setup Code Climate test-reporter
-          command: |
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 -o ./cc-test-reporter
-            chmod +x ./cc-test-reporter
-
       # Bundle install dependencies
       - run: gem install bundler -v 1.17.3 --no-document
       - run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
@@ -64,9 +58,7 @@ jobs:
       - run:
           name: rails-5.2-sidekiq-5.2
           command: |
-            ./cc-test-reporter before-build
             bundle exec appraisal rails-5.2-sidekiq-5.2 rspec --format RspecJunitFormatter --format progress
-            ./cc-test-reporter after-build -t simplecov --exit-code $? || exit 0
 
       - run:
           name: rails-5.2-sidekiq-6.0


### PR DESCRIPTION
## What did we change?

- Removed the Code Climate configuration.

## Why are we doing this?

We don't appear to be using this anymore and I couldn't find the project in Code Climate.