### PR TITLE
[RLSH-503] Add support for ActiveSupport 7.1, drop support for Sidekiq < 6.4.1

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,37 +1,37 @@
 # frozen_string_literal: true
 
-appraise "rails-6.1-sidekiq-5.2" do
-  gem "activejob", "~> 6.1.0"
-  gem "activesupport", "~> 6.1.0"
-  gem "sidekiq", "~> 5.2.0"
-end
-
-appraise "rails-6.1-sidekiq-6.0" do
-  gem "activejob", "~> 6.1.0"
-  gem "activesupport", "~> 6.1.0"
-  gem "sidekiq", "~> 6.0.1"
-end
-
-appraise "rails-6.1-sidekiq-6.1" do
-  gem "activejob", "~> 6.1.0"
-  gem "activesupport", "~> 6.1.0"
-  gem "sidekiq", "~> 6.1.0"
-end
-
-appraise "rails-6.1-sidekiq-6.2" do
-  gem "activejob", "~> 6.1.0"
-  gem "activesupport", "~> 6.1.0"
-  gem "sidekiq", "~> 6.2.0"
-end
-
-appraise "rails-6.1-sidekiq-6.3" do
-  gem "activejob", "~> 6.1.0"
-  gem "activesupport", "~> 6.1.0"
-  gem "sidekiq", "~> 6.3.0"
-end
-
 appraise "rails-6.1-sidekiq-6.4" do
   gem "activejob", "~> 6.1.0"
   gem "activesupport", "~> 6.1.0"
-  gem "sidekiq", "~> 6.4.2" # above 6.4.2 to ensure we test against breaking changes
+  gem "sidekiq", "~> 6.4.1"
+end
+
+appraise "rails-6.1-sidekiq-6.5" do
+  gem "activejob", "~> 6.1.0"
+  gem "activesupport", "~> 6.1.0"
+  gem "sidekiq", "~> 6.5.0"
+end
+
+appraise "rails-7.0-sidekiq-6.4" do
+  gem "activejob", "~> 7.0.0"
+  gem "activesupport", "~> 7.0.0"
+  gem "sidekiq", "~> 6.4.1"
+end
+
+appraise "rails-7.0-sidekiq-6.5" do
+  gem "activejob", "~> 7.0.0"
+  gem "activesupport", "~> 7.0.0"
+  gem "sidekiq", "~> 6.5.0"
+end
+
+appraise "rails-7.1-sidekiq-6.4" do
+  gem "activejob", "~> 7.1.0"
+  gem "activesupport", "~> 7.1.0"
+  gem "sidekiq", "~> 6.4.1"
+end
+
+appraise "rails-7.1-sidekiq-6.5" do
+  gem "activejob", "~> 7.1.0"
+  gem "activesupport", "~> 7.1.0"
+  gem "sidekiq", "~> 6.5.0"
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # sidekiq_publisher
 
+## 5.0.0
+- BREAKING: Drop support for Sidekiq < 6.1.
+- Add support for ActiveSupport and ActiveJob 7.1
+
 ## 4.0.0
 - BREAKING: Enqueue directly to Redis unless in a transaction ([#74](https://github.com/ezcater/sidekiq_publisher/pull/74/))
 

--- a/gemfiles/rails_6.1_sidekiq_6.4.gemfile
+++ b/gemfiles/rails_6.1_sidekiq_6.4.gemfile
@@ -4,6 +4,6 @@ source "https://rubygems.org"
 
 gem "activejob", "~> 6.1.0"
 gem "activesupport", "~> 6.1.0"
-gem "sidekiq", "~> 6.4.2"
+gem "sidekiq", "~> 6.4.1"
 
 gemspec path: "../"

--- a/gemfiles/rails_6.1_sidekiq_6.5.gemfile
+++ b/gemfiles/rails_6.1_sidekiq_6.5.gemfile
@@ -4,6 +4,6 @@ source "https://rubygems.org"
 
 gem "activejob", "~> 6.1.0"
 gem "activesupport", "~> 6.1.0"
-gem "sidekiq", "~> 6.2.0"
+gem "sidekiq", "~> 6.5.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.0_sidekiq_6.4.gemfile
+++ b/gemfiles/rails_7.0_sidekiq_6.4.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "activejob", "~> 6.1.0"
-gem "activesupport", "~> 6.1.0"
-gem "sidekiq", "~> 5.2.0"
+gem "activejob", "~> 7.0.0"
+gem "activesupport", "~> 7.0.0"
+gem "sidekiq", "~> 6.4.1"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.0_sidekiq_6.5.gemfile
+++ b/gemfiles/rails_7.0_sidekiq_6.5.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "activejob", "~> 6.1.0"
-gem "activesupport", "~> 6.1.0"
-gem "sidekiq", "~> 6.3.0"
+gem "activejob", "~> 7.0.0"
+gem "activesupport", "~> 7.0.0"
+gem "sidekiq", "~> 6.5.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.1_sidekiq_6.4.gemfile
+++ b/gemfiles/rails_7.1_sidekiq_6.4.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "activejob", "~> 6.1.0"
-gem "activesupport", "~> 6.1.0"
-gem "sidekiq", "~> 6.0.1"
+gem "activejob", "~> 7.1.0"
+gem "activesupport", "~> 7.1.0"
+gem "sidekiq", "~> 6.4.1"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.1_sidekiq_6.5.gemfile
+++ b/gemfiles/rails_7.1_sidekiq_6.5.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "activejob", "~> 6.1.0"
-gem "activesupport", "~> 6.1.0"
-gem "sidekiq", "~> 6.1.0"
+gem "activejob", "~> 7.1.0"
+gem "activesupport", "~> 7.1.0"
+gem "sidekiq", "~> 6.5.0"
 
 gemspec path: "../"

--- a/lib/sidekiq_publisher/version.rb
+++ b/lib/sidekiq_publisher/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqPublisher
-  VERSION = "4.0.0"
+  VERSION = "5.0.0"
 end

--- a/sidekiq_publisher.gemspec
+++ b/sidekiq_publisher.gemspec
@@ -60,6 +60,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", "< 0.18"
 
   spec.add_runtime_dependency "activerecord-postgres_pub_sub", ">= 0.4.0"
-  spec.add_runtime_dependency "activesupport", ">= 6.1", "< 7.1"
-  spec.add_runtime_dependency "sidekiq", ">= 5.0.4", "< 7"
+  spec.add_runtime_dependency "activesupport", ">= 6.1", "< 7.2"
+  spec.add_runtime_dependency "sidekiq", ">= 6.4.1", "< 7"
 end


### PR DESCRIPTION
## What did we change?
- Added support for `ActiveSupport` and `ActiveJob` `7.1`.
- Dropped support for `Sidekiq` `< 6.4.1`.
- Updated `appraisals` to support the current versions of `ActiveSupport` and `Sidekiq`. 
- Bump version to `5.0.0` 

## Why are we doing this?
This is the outcome of a conversation that can be found [here](https://ezcater.slack.com/archives/C94MF14JF/p1707762215396929).

## How was it tested?
- [ ] Specs
- [ ] Locally
- [ ] Staging
