### PR TITLE
chore: Rename Demand Scalability to Monolith Experience

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ezcater/demand-scalability
+* @ezcater/monolith-experience


### PR DESCRIPTION
## What did we change?

Renamed "Demand Scalability" to "Monolith Experience" everywhere that I could find.

## Why are we doing this?

We've changed our name as a team. We've already updated our Slack channel names and created a new GitHub team. As described in [our plan](https://ezcater.atlassian.net/wiki/spaces/POL/pages/4169531772/Renaming+a+team#Code), we'll merge this PR when we have PRs ready to merge for all the other repos we own and have swapped most of our team members into the new team.

### Jira Ticket Link

https://ezcater.atlassian.net/browse/DEM-573