### PR TITLE
feat: Add stage_to_database_outside_transaction configuration option

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -2,36 +2,42 @@
 
 appraise "rails-6.1-sidekiq-6.4" do
   gem "activejob", "~> 6.1.0"
+  gem "activerecord", "~> 6.1.0"
   gem "activesupport", "~> 6.1.0"
   gem "sidekiq", "~> 6.4.1"
 end
 
 appraise "rails-6.1-sidekiq-6.5" do
   gem "activejob", "~> 6.1.0"
+  gem "activerecord", "~> 6.1.0"
   gem "activesupport", "~> 6.1.0"
   gem "sidekiq", "~> 6.5.0"
 end
 
 appraise "rails-7.0-sidekiq-6.4" do
   gem "activejob", "~> 7.0.0"
+  gem "activerecord", "~> 7.0.0"
   gem "activesupport", "~> 7.0.0"
   gem "sidekiq", "~> 6.4.1"
 end
 
 appraise "rails-7.0-sidekiq-6.5" do
   gem "activejob", "~> 7.0.0"
+  gem "activerecord", "~> 7.0.0"
   gem "activesupport", "~> 7.0.0"
   gem "sidekiq", "~> 6.5.0"
 end
 
 appraise "rails-7.1-sidekiq-6.4" do
   gem "activejob", "~> 7.1.0"
+  gem "activerecord", "~> 7.1.0"
   gem "activesupport", "~> 7.1.0"
   gem "sidekiq", "~> 6.4.1"
 end
 
 appraise "rails-7.1-sidekiq-6.5" do
   gem "activejob", "~> 7.1.0"
+  gem "activerecord", "~> 7.1.0"
   gem "activesupport", "~> 7.1.0"
   gem "sidekiq", "~> 6.5.0"
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # sidekiq_publisher
 
-## 5.1.0
+## 6.0.0
+- BREAKING: Remove SidekiqPublisher::DatabaseConnection.transaction_open? method
 - Add stage_to_database_outside_transaction configuration option
 
 ## 5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # sidekiq_publisher
 
+## 5.1.0
+- Add stage_to_database_outside_transaction configuration option
+
 ## 5.0.0
 - BREAKING: Drop support for Sidekiq < 6.1.
 - Add support for ActiveSupport and ActiveJob 7.1

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ publisher process handles retries and ensure that each job is delivered to Sidek
 > :warning: Not all jobs are staged in Postgres. This is determined dynamically:
 > if the job is enqueued from within an `ActiveRecord` transaction, then it is
 > staged in Postgres. If not, then it bypasses Postgres and is enqueued directly
-> to Redis via Sidekiq.
+> to Redis via Sidekiq. To opt out of this behavior configure with
+> SidekiqPublisher.configure { |c| c.stage_to_database_outside_transaction = true }
 
 ## Installation
 

--- a/gemfiles/rails_6.1_sidekiq_6.4.gemfile
+++ b/gemfiles/rails_6.1_sidekiq_6.4.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "activejob", "~> 6.1.0"
+gem "activerecord", "~> 6.1.0"
 gem "activesupport", "~> 6.1.0"
 gem "sidekiq", "~> 6.4.1"
 

--- a/gemfiles/rails_6.1_sidekiq_6.5.gemfile
+++ b/gemfiles/rails_6.1_sidekiq_6.5.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "activejob", "~> 6.1.0"
+gem "activerecord", "~> 6.1.0"
 gem "activesupport", "~> 6.1.0"
 gem "sidekiq", "~> 6.5.0"
 

--- a/gemfiles/rails_7.0_sidekiq_6.4.gemfile
+++ b/gemfiles/rails_7.0_sidekiq_6.4.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "activejob", "~> 7.0.0"
+gem "activerecord", "~> 7.0.0"
 gem "activesupport", "~> 7.0.0"
 gem "sidekiq", "~> 6.4.1"
 

--- a/gemfiles/rails_7.0_sidekiq_6.5.gemfile
+++ b/gemfiles/rails_7.0_sidekiq_6.5.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "activejob", "~> 7.0.0"
+gem "activerecord", "~> 7.0.0"
 gem "activesupport", "~> 7.0.0"
 gem "sidekiq", "~> 6.5.0"
 

--- a/gemfiles/rails_7.1_sidekiq_6.4.gemfile
+++ b/gemfiles/rails_7.1_sidekiq_6.4.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "activejob", "~> 7.1.0"
+gem "activerecord", "~> 7.1.0"
 gem "activesupport", "~> 7.1.0"
 gem "sidekiq", "~> 6.4.1"
 

--- a/gemfiles/rails_7.1_sidekiq_6.5.gemfile
+++ b/gemfiles/rails_7.1_sidekiq_6.5.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "activejob", "~> 7.1.0"
+gem "activerecord", "~> 7.1.0"
 gem "activesupport", "~> 7.1.0"
 gem "sidekiq", "~> 6.5.0"
 

--- a/lib/active_job/queue_adapters/sidekiq_publisher_adapter.rb
+++ b/lib/active_job/queue_adapters/sidekiq_publisher_adapter.rb
@@ -11,7 +11,7 @@ module ActiveJob
       JOB_WRAPPER_CLASS = ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper.to_s.freeze
 
       def enqueue(job)
-        if SidekiqPublisher::DatabaseConnection.transaction_open?
+        if SidekiqPublisher::DatabaseConnection.should_stage_to_database?
           create_job_record(job)
         else
           sidekiq_adapter.enqueue(job)
@@ -19,7 +19,7 @@ module ActiveJob
       end
 
       def enqueue_at(job, timestamp)
-        if SidekiqPublisher::DatabaseConnection.transaction_open?
+        if SidekiqPublisher::DatabaseConnection.should_stage_to_database?
           create_job_record(job, timestamp)
         else
           sidekiq_adapter.enqueue_at(job, timestamp)

--- a/lib/sidekiq_publisher.rb
+++ b/lib/sidekiq_publisher.rb
@@ -19,7 +19,7 @@ module SidekiqPublisher
   DEFAULT_JOB_RETENTION_PERIOD = 1.day.freeze
 
   class << self
-    attr_accessor :logger, :exception_reporter, :metrics_reporter
+    attr_accessor :logger, :exception_reporter, :metrics_reporter, :stage_to_database_outside_transaction
     attr_writer :batch_size, :job_retention_period
 
     def configure
@@ -36,6 +36,7 @@ module SidekiqPublisher
 
     # For test purposes
     def reset!
+      @stage_to_database_outside_transaction = nil
       @batch_size = nil
       @job_retention_period = nil
       @exception_reporter = nil

--- a/lib/sidekiq_publisher.rb
+++ b/lib/sidekiq_publisher.rb
@@ -2,7 +2,7 @@
 
 # FIXES: uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger
 require "logger"
-require "activerecord"
+require "active_record"
 require "active_support"
 require "active_support/core_ext/numeric/time"
 require "sidekiq_publisher/version"

--- a/lib/sidekiq_publisher.rb
+++ b/lib/sidekiq_publisher.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# FIXES: uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger
+require "logger"
+require "activerecord"
 require "active_support"
 require "active_support/core_ext/numeric/time"
 require "sidekiq_publisher/version"

--- a/lib/sidekiq_publisher/database_connection.rb
+++ b/lib/sidekiq_publisher/database_connection.rb
@@ -2,13 +2,9 @@
 
 module SidekiqPublisher
   module DatabaseConnection
-    # TODO: this is deprecated and should not be used outside if this class
-    def self.transaction_open?
-      ActiveRecord::Base.connection.transaction_open?
-    end
-
     def self.should_stage_to_database?
-      SidekiqPublisher.stage_to_database_outside_transaction || transaction_open?
+      SidekiqPublisher.stage_to_database_outside_transaction ||
+        ActiveRecord::Base.connection.transaction_open?
     end
   end
 end

--- a/lib/sidekiq_publisher/database_connection.rb
+++ b/lib/sidekiq_publisher/database_connection.rb
@@ -2,8 +2,13 @@
 
 module SidekiqPublisher
   module DatabaseConnection
+    # TODO: this is deprecated and should not be used outside if this class
     def self.transaction_open?
       ActiveRecord::Base.connection.transaction_open?
+    end
+
+    def self.should_stage_to_database?
+      SidekiqPublisher.stage_to_database_outside_transaction || transaction_open?
     end
   end
 end

--- a/lib/sidekiq_publisher/version.rb
+++ b/lib/sidekiq_publisher/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqPublisher
-  VERSION = "5.1.0"
+  VERSION = "6.0.0"
 end

--- a/lib/sidekiq_publisher/version.rb
+++ b/lib/sidekiq_publisher/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqPublisher
-  VERSION = "5.0.0"
+  VERSION = "5.1.0"
 end

--- a/lib/sidekiq_publisher/worker.rb
+++ b/lib/sidekiq_publisher/worker.rb
@@ -10,7 +10,7 @@ module SidekiqPublisher
 
     module ClassMethods
       def client_push(item)
-        if SidekiqPublisher::DatabaseConnection.transaction_open?
+        if SidekiqPublisher::DatabaseConnection.should_stage_to_database?
           SidekiqPublisher::Job.create_job!(item)
         else
           super

--- a/sidekiq_publisher.gemspec
+++ b/sidekiq_publisher.gemspec
@@ -59,8 +59,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "shoulda-matchers"
   spec.add_development_dependency "simplecov", "< 0.18"
 
-  spec.add_runtime_dependency "activerecord-postgres_pub_sub", ">= 0.4.0"
   spec.add_runtime_dependency "activerecord", ">= 6.1", "< 7.2"
+  spec.add_runtime_dependency "activerecord-postgres_pub_sub", ">= 0.4.0"
   spec.add_runtime_dependency "activesupport", ">= 6.1", "< 7.2"
   spec.add_runtime_dependency "sidekiq", ">= 6.4.1", "< 7"
 end

--- a/sidekiq_publisher.gemspec
+++ b/sidekiq_publisher.gemspec
@@ -60,6 +60,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", "< 0.18"
 
   spec.add_runtime_dependency "activerecord-postgres_pub_sub", ">= 0.4.0"
+  spec.add_runtime_dependency "activerecord", ">= 6.1", "< 7.2"
   spec.add_runtime_dependency "activesupport", ">= 6.1", "< 7.2"
   spec.add_runtime_dependency "sidekiq", ">= 6.4.1", "< 7"
 end

--- a/spec/active_job/queue_adapters/sidekiq_publisher_adapter_spec.rb
+++ b/spec/active_job/queue_adapters/sidekiq_publisher_adapter_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ActiveJob::QueueAdapters::SidekiqPublisherAdapter do
       end
     end
 
-    context "when not in a transaction", skip_db_clean: true do
+    context "when not in a transaction", run_outside_transaction: true do
       it "does not create a SidekiqPublisher job record" do
         active_job.enqueue
 
@@ -86,7 +86,7 @@ RSpec.describe ActiveJob::QueueAdapters::SidekiqPublisherAdapter do
       end
     end
 
-    context "when not in a transaction", skip_db_clean: true do
+    context "when not in a transaction", run_outside_transaction: true do
       it "does not create a SidekiqPublisher job record" do
         active_job.enqueue(wait_until: scheduled_at)
 
@@ -125,7 +125,7 @@ RSpec.describe ActiveJob::QueueAdapters::SidekiqPublisherAdapter do
       end
     end
 
-    context "when not in a transaction", skip_db_clean: true do
+    context "when not in a transaction", run_outside_transaction: true do
       it "does not create a SidekiqPublisher job record" do
         job_class.perform_later(*args)
 

--- a/spec/sidekiq_publisher/instrumenter_spec.rb
+++ b/spec/sidekiq_publisher/instrumenter_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe SidekiqPublisher::Instrumenter, skip_db_clean: true do
+RSpec.describe SidekiqPublisher::Instrumenter, run_outside_transaction: true do
   let(:instrumenter) { described_class.new }
   let(:payload) { Hash.new[a: 1] }
 

--- a/spec/sidekiq_publisher/runner_spec.rb
+++ b/spec/sidekiq_publisher/runner_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe SidekiqPublisher::Runner, cleaner_strategy: :truncation do
+RSpec.describe SidekiqPublisher::Runner, run_outside_transaction: true do
   let(:timeout) { 60 }
   let(:counter) { Hash.new(0) }
   let(:publisher) { instance_double(SidekiqPublisher::Publisher) }

--- a/spec/sidekiq_publisher/worker_spec.rb
+++ b/spec/sidekiq_publisher/worker_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe SidekiqPublisher::Worker do
       end
     end
 
-    context "when not in a transaction", skip_db_clean: true do
+    context "when not in a transaction", run_outside_transaction: true do
       it "does not create a SidekiqPublisher job record" do
         TestWorker.perform_async(*args)
 
@@ -135,7 +135,7 @@ RSpec.describe SidekiqPublisher::Worker do
       end
     end
 
-    context "when not in a transaction", skip_db_clean: true do
+    context "when not in a transaction", run_outside_transaction: true do
       it "does not create a SidekiqPublisher job record" do
         TestWorker.perform_in(1.hour, *args)
 
@@ -176,7 +176,7 @@ RSpec.describe SidekiqPublisher::Worker do
       end
     end
 
-    context "when not in a transaction", skip_db_clean: true do
+    context "when not in a transaction", run_outside_transaction: true do
       it "does not create a SidekiqPublisher job record" do
         TestWorker.perform_at(run_at, *args)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "simplecov"
 SimpleCov.start
 
-require "active_record"
+require "sidekiq_publisher"
 require "sidekiq_publisher/job"
 
 require "active_support/notifications"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -89,14 +89,16 @@ RSpec.configure do |config|
   end
 
   config.before do |example|
-    unless example.metadata.fetch(:skip_db_clean, false)
-      DatabaseCleaner.strategy = example.metadata.fetch(:cleaner_strategy, :transaction)
+    if example.metadata.fetch(:run_outside_transaction, false)
+      DatabaseCleaner.strategy = :truncation
+    else
+      DatabaseCleaner.strategy = :transaction
       DatabaseCleaner.start
     end
   end
 
-  config.after do |example|
-    DatabaseCleaner.clean unless example.metadata.fetch(:skip_db_clean, false)
+  config.after do |_example|
+    DatabaseCleaner.clean
   end
 
   config.include RedisHelpers


### PR DESCRIPTION
## What did we change?

This adds a `stage_to_database_outside_transaction` configuration option to allow for users to opt out of https://github.com/ezcater/sidekiq_publisher/pull/74/ in order to derisk an upgrade to the latest version.

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
